### PR TITLE
[WIP] Update CRD Spec for etcd, adds etcd statefulset spec

### DIFF
--- a/operator/config/control-plane-crd.yaml
+++ b/operator/config/control-plane-crd.yaml
@@ -30,8 +30,6 @@ spec:
                   properties:
                     ami:
                       type: string
-                    replicas:
-                      type: integer
                     spec:
                       properties:
                         activeDeadlineSeconds:

--- a/operator/pkg/apis/config/default.go
+++ b/operator/pkg/apis/config/default.go
@@ -1,0 +1,19 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+const (
+	DefaultKubernetesVersion = "1.19"
+)

--- a/operator/pkg/apis/infrastructure/v1alpha1/controlplane.go
+++ b/operator/pkg/apis/infrastructure/v1alpha1/controlplane.go
@@ -59,8 +59,8 @@ type MasterSpec struct {
 
 // ETCDSpec provides a way to configure the etcd nodes and args which are passed to the etcd process.
 type ETCDSpec struct {
-	Instances  `json:",inline"`
-	*Component `json:",inline"`
+	Instances `json:",inline"`
+	Spec      *v1.PodSpec `json:"spec,omitempty"`
 }
 
 // Component provides a generic way to pass in args and images to master and etcd

--- a/operator/pkg/apis/infrastructure/v1alpha1/controlplane_defaults.go
+++ b/operator/pkg/apis/infrastructure/v1alpha1/controlplane_defaults.go
@@ -16,6 +16,11 @@ package v1alpha1
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 // SetDefaults for the ControlPlane, this gets called by the kit-webhook pod
@@ -28,3 +33,65 @@ func (c *ControlPlane) SetDefaults(ctx context.Context) {
 
 // SetDefaults for the ControlPlaneSpec, cascading to all subspecs
 func (s *ControlPlaneSpec) SetDefaults(ctx context.Context) {}
+
+// WithStaticDefaults
+func (p *ControlPlaneSpec) WithStaticDefaults(defaultStaticSpec func() *ControlPlaneSpec) (_ ControlPlaneSpec, err error) {
+	userConfig := p.DeepCopy()
+	patchedCPSpec, err := defaultStaticSpec().Patch(userConfig)
+	return patchedCPSpec, err
+}
+
+// Patch will overwrite the receiver with desired fields in the parameter provided
+func (c *ControlPlaneSpec) Patch(patch *ControlPlaneSpec) (spec ControlPlaneSpec, err error) {
+	if patch.KubernetesVersion != "" {
+		c.KubernetesVersion = patch.KubernetesVersion
+	}
+	if c.Etcd, err = patch.Etcd.WithStaticDefaults(context.TODO(), func() *ETCDSpec {
+		return &c.Etcd
+	}); err != nil {
+		return ControlPlaneSpec{}, err
+	}
+	return *c, err
+}
+
+func (s *ETCDSpec) WithStaticDefaults(ctx context.Context, defaultStaticSpec func() *ETCDSpec) (_ ETCDSpec, err error) {
+	spec := s.DeepCopy()
+	patchedEtcdSpec, err := defaultStaticSpec().Patch(spec)
+	return patchedEtcdSpec, err
+}
+
+func (s *ETCDSpec) Patch(patch *ETCDSpec) (ETCDSpec, error) {
+	if patch.Instances.AMI != "" {
+		s.Instances.AMI = patch.Instances.AMI
+	}
+	if patch.Instances.Type != "" {
+		s.Instances.Type = patch.Instances.Type
+	}
+	if patch.Spec != nil {
+		obj := v1.PodSpec{}
+		mergedPatch, err := mergePatch(s.Spec, patch.Spec, obj)
+		if err != nil {
+			return ETCDSpec{}, fmt.Errorf("failed to merge patch, %w", err)
+		}
+		if err := json.Unmarshal(mergedPatch, s.Spec); err != nil {
+			return ETCDSpec{}, fmt.Errorf("unmarshalling mergedPatch to podSpec, %w", err)
+		}
+	}
+	return *s, nil
+}
+
+func mergePatch(defaultObj, patch, object interface{}) ([]byte, error) {
+	defaultSpecBytes, err := json.Marshal(defaultObj)
+	if err != nil {
+		return nil, err
+	}
+	patchSpecBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+	patchedBytes, err := strategicpatch.StrategicMergePatch(defaultSpecBytes, patchSpecBytes, object)
+	if err != nil {
+		return nil, fmt.Errorf("json merge patch, %w", err)
+	}
+	return patchedBytes, nil
+}

--- a/operator/pkg/apis/infrastructure/v1alpha1/controlplane_defaults.go
+++ b/operator/pkg/apis/infrastructure/v1alpha1/controlplane_defaults.go
@@ -16,11 +16,8 @@ package v1alpha1
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"github.com/awslabs/kit/operator/pkg/apis/config"
 )
 
 // SetDefaults for the ControlPlane, this gets called by the kit-webhook pod
@@ -32,66 +29,8 @@ func (c *ControlPlane) SetDefaults(ctx context.Context) {
 }
 
 // SetDefaults for the ControlPlaneSpec, cascading to all subspecs
-func (s *ControlPlaneSpec) SetDefaults(ctx context.Context) {}
-
-// WithStaticDefaults
-func (p *ControlPlaneSpec) WithStaticDefaults(defaultStaticSpec func() *ControlPlaneSpec) (_ ControlPlaneSpec, err error) {
-	userConfig := p.DeepCopy()
-	patchedCPSpec, err := defaultStaticSpec().Patch(userConfig)
-	return patchedCPSpec, err
-}
-
-// Patch will overwrite the receiver with desired fields in the parameter provided
-func (c *ControlPlaneSpec) Patch(patch *ControlPlaneSpec) (spec ControlPlaneSpec, err error) {
-	if patch.KubernetesVersion != "" {
-		c.KubernetesVersion = patch.KubernetesVersion
+func (s *ControlPlaneSpec) SetDefaults(ctx context.Context) {
+	if s.KubernetesVersion == "" {
+		s.KubernetesVersion = config.DefaultKubernetesVersion
 	}
-	if c.Etcd, err = patch.Etcd.WithStaticDefaults(context.TODO(), func() *ETCDSpec {
-		return &c.Etcd
-	}); err != nil {
-		return ControlPlaneSpec{}, err
-	}
-	return *c, err
-}
-
-func (s *ETCDSpec) WithStaticDefaults(ctx context.Context, defaultStaticSpec func() *ETCDSpec) (_ ETCDSpec, err error) {
-	spec := s.DeepCopy()
-	patchedEtcdSpec, err := defaultStaticSpec().Patch(spec)
-	return patchedEtcdSpec, err
-}
-
-func (s *ETCDSpec) Patch(patch *ETCDSpec) (ETCDSpec, error) {
-	if patch.Instances.AMI != "" {
-		s.Instances.AMI = patch.Instances.AMI
-	}
-	if patch.Instances.Type != "" {
-		s.Instances.Type = patch.Instances.Type
-	}
-	if patch.Spec != nil {
-		obj := v1.PodSpec{}
-		mergedPatch, err := mergePatch(s.Spec, patch.Spec, obj)
-		if err != nil {
-			return ETCDSpec{}, fmt.Errorf("failed to merge patch, %w", err)
-		}
-		if err := json.Unmarshal(mergedPatch, s.Spec); err != nil {
-			return ETCDSpec{}, fmt.Errorf("unmarshalling mergedPatch to podSpec, %w", err)
-		}
-	}
-	return *s, nil
-}
-
-func mergePatch(defaultObj, patch, object interface{}) ([]byte, error) {
-	defaultSpecBytes, err := json.Marshal(defaultObj)
-	if err != nil {
-		return nil, err
-	}
-	patchSpecBytes, err := json.Marshal(patch)
-	if err != nil {
-		return nil, err
-	}
-	patchedBytes, err := strategicpatch.StrategicMergePatch(defaultSpecBytes, patchSpecBytes, object)
-	if err != nil {
-		return nil, fmt.Errorf("json merge patch, %w", err)
-	}
-	return patchedBytes, nil
 }

--- a/operator/pkg/apis/infrastructure/v1alpha1/zz_generated.deepcopy.go
+++ b/operator/pkg/apis/infrastructure/v1alpha1/zz_generated.deepcopy.go
@@ -146,9 +146,9 @@ func (in *ControlPlaneStatus) DeepCopy() *ControlPlaneStatus {
 func (in *ETCDSpec) DeepCopyInto(out *ETCDSpec) {
 	*out = *in
 	out.Instances = in.Instances
-	if in.Component != nil {
-		in, out := &in.Component, &out.Component
-		*out = new(Component)
+	if in.Spec != nil {
+		in, out := &in.Spec, &out.Spec
+		*out = new(v1.PodSpec)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/operator/pkg/controllers/controlplane/controlplane.go
+++ b/operator/pkg/controllers/controlplane/controlplane.go
@@ -27,10 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	defaultKubernetesVersion = "1.19"
-)
-
 type controlPlane struct {
 	ec2api       *awsprovider.EC2
 	etcdProvider *etcd.Provider
@@ -56,10 +52,6 @@ func (c *controlPlane) For() controllers.Object {
 // object
 func (c *controlPlane) Reconcile(ctx context.Context, object controllers.Object) (result *reconcile.Result, err error) {
 	controlPlane := object.(*v1alpha1.ControlPlane)
-	// var err error
-	if controlPlane.Spec, err = controlPlane.Spec.WithStaticDefaults(c.DefaultStaticSpecFor(controlPlane)); err != nil {
-		return nil, err
-	}
 	// TODO create karpenter provisioner spec for creating new nodes.
 	// deploy etcd to the management cluster
 	if err := c.etcdProvider.Reconcile(ctx, controlPlane); err != nil {
@@ -71,13 +63,4 @@ func (c *controlPlane) Reconcile(ctx context.Context, object controllers.Object)
 
 func (c *controlPlane) Finalize(_ context.Context, _ controllers.Object) (*reconcile.Result, error) {
 	return status.Terminated, nil
-}
-
-func (c *controlPlane) DefaultStaticSpecFor(controlPlane *v1alpha1.ControlPlane) func() *v1alpha1.ControlPlaneSpec {
-	return func() *v1alpha1.ControlPlaneSpec {
-		return &v1alpha1.ControlPlaneSpec{
-			KubernetesVersion: defaultKubernetesVersion,
-			Etcd:              *c.etcdProvider.DefaultStaticSpecFor(controlPlane)(),
-		}
-	}
 }

--- a/operator/pkg/controllers/etcd/defaultspec.go
+++ b/operator/pkg/controllers/etcd/defaultspec.go
@@ -1,0 +1,190 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/awslabs/kit/operator/pkg/apis/infrastructure/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	defaultEtcdReplicas = 3
+	defaultEtcdImage    = "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.14-eks-1-18-1"
+)
+
+func (e *Provider) DefaultStaticSpecFor(controlPlane *v1alpha1.ControlPlane) func() *v1alpha1.ETCDSpec {
+	return func() *v1alpha1.ETCDSpec {
+		return &v1alpha1.ETCDSpec{
+			Spec: &v1.PodSpec{
+				TerminationGracePeriodSeconds: aws.Int64(1),
+				HostNetwork:                   true,
+				DNSPolicy:                     v1.DNSClusterFirstWithHostNet,
+				Containers: []v1.Container{{
+					Name:  "etcd",
+					Image: defaultEtcdImage,
+					Ports: []v1.ContainerPort{{
+						ContainerPort: 2379,
+						Name:          "etcd",
+					}, {
+						ContainerPort: 2380,
+						Name:          "etcd-peer",
+					}},
+					VolumeMounts: []v1.VolumeMount{{
+						Name:      "etcd-data",
+						MountPath: "/var/lib/etcd",
+					}, {
+						Name:      "etcd-ca",
+						MountPath: "/etc/kubernetes/pki",
+					}, {
+						Name:      "etcd-peer-certs",
+						MountPath: "/etc/kubernetes/pki/etcd/peer",
+					}, {
+						Name:      "etcd-server-certs",
+						MountPath: "/etc/kubernetes/pki/etcd/server",
+					}},
+					Command: []string{"etcd"},
+					Args: []string{
+						"--cert-file=/etc/kubernetes/pki/etcd/server/server.crt",
+						"--initial-cluster=" + initialClusterFlag(controlPlane),
+						"--data-dir=/var/lib/etcd",
+						"--initial-cluster-state=new",
+						"--initial-cluster-token=etcd-cluster-1",
+						"--key-file=/etc/kubernetes/pki/etcd/server/server.key",
+						"--advertise-client-urls=" + advertizeClusterURL(controlPlane),
+						"--initial-advertise-peer-urls=" + advertizePeerURL(controlPlane),
+						"--listen-client-urls=https://$(NODE_IP):2379,https://127.0.0.1:2379",
+						"--listen-metrics-urls=http://127.0.0.1:2381",
+						"--listen-peer-urls=https://$(NODE_IP):2380",
+						"--name=$(NODE_ID)",
+						"--peer-cert-file=/etc/kubernetes/pki/etcd/peer/peer.crt",
+						"--peer-client-cert-auth=true",
+						"--peer-key-file=/etc/kubernetes/pki/etcd/peer/peer.key",
+						"--peer-trusted-ca-file=/etc/kubernetes/pki/ca.crt",
+						"--snapshot-count=10000",
+						"--trusted-ca-file=/etc/kubernetes/pki/ca.crt",
+						"--logger=zap",
+					},
+					Env: []v1.EnvVar{{
+						Name: "NODE_IP",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								FieldPath: "status.podIP",
+							},
+						},
+					}, {
+						Name: "NODE_ID",
+						ValueFrom: &v1.EnvVarSource{
+							FieldRef: &v1.ObjectFieldSelector{
+								FieldPath: "metadata.name",
+							},
+						},
+					}},
+				}},
+				Volumes: []v1.Volume{{
+					Name: "etcd-data",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: "/var/lib/etcd",
+						},
+					},
+				}, {
+					Name: "etcd-ca",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  caSecretName(controlPlane),
+							DefaultMode: aws.Int32(0400),
+							Items: []v1.KeyToPath{{
+								Key:  "tls.crt",
+								Path: "ca.crt",
+							}, {
+								Key:  "tls.key",
+								Path: "ca.key",
+							}},
+						},
+					},
+				}, {
+					Name: "etcd-peer-certs",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  caPeerName(controlPlane),
+							DefaultMode: aws.Int32(0400),
+							Items: []v1.KeyToPath{{
+								Key:  "tls.crt",
+								Path: "peer.crt",
+							}, {
+								Key:  "tls.key",
+								Path: "peer.key",
+							}},
+						},
+					},
+				}, {
+					Name: "etcd-server-certs",
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{
+							SecretName:  caServerName(controlPlane),
+							DefaultMode: aws.Int32(0400),
+							Items: []v1.KeyToPath{{
+								Key:  "tls.crt",
+								Path: "server.crt",
+							}, {
+								Key:  "tls.key",
+								Path: "server.key",
+							}},
+						},
+					},
+				}},
+			},
+		}
+	}
+}
+
+func initialClusterFlag(controlPlane *v1alpha1.ControlPlane) string {
+	nodes := make([]string, 0)
+	for i := 0; i < defaultEtcdReplicas; i++ {
+		nodes = append(nodes, fmt.Sprintf("%[1]s-etcd-%[2]d=https://%[1]s-etcd-%[2]d.%[1]s-etcd.%[3]s.svc.cluster.local:2380", controlPlane.ClusterName(), i, controlPlane.NamespaceName()))
+	}
+	return strings.Join(nodes, ",")
+}
+
+func advertizeClusterURL(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("https://%s:2379,https://%s:2379", podFQDN(controlPlane), serviceFQDN(controlPlane))
+}
+
+func advertizePeerURL(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("https://%s:2380", podFQDN(controlPlane))
+}
+
+func podFQDN(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("$(NODE_ID).%s-etcd.%s.svc.cluster.local", controlPlane.ClusterName(), controlPlane.NamespaceName())
+}
+
+func serviceFQDN(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("%s-etcd.%s.svc.cluster.local", controlPlane.ClusterName(), controlPlane.NamespaceName())
+}
+
+func caSecretName(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("%s-etcd-ca", controlPlane.ClusterName())
+}
+
+func caServerName(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("%s-etcd-server", controlPlane.ClusterName())
+}
+func caPeerName(controlPlane *v1alpha1.ControlPlane) string {
+	return fmt.Sprintf("%s-etcd-peer", controlPlane.ClusterName())
+}

--- a/operator/pkg/pki/pki.go
+++ b/operator/pkg/pki/pki.go
@@ -51,7 +51,7 @@ func RootCA(config *CertConfig) (certBytes, keyBytes []byte, err error) {
 	// verify the existing certs if valid use
 	cert, key, err := validCerts(config.ExistingCert, config.ExistingKey)
 	if err == nil {
-		zap.S().Infof("Reusing existing certs for %s", config.CommonName)
+		zap.S().Debugf("Reusing existing root CA certs for %s", config.CommonName)
 	} else {
 		// create private key, defaults to x509.RSA
 		if key, err = rsa.GenerateKey(cryptorand.Reader, rsaKeySize); err != nil {
@@ -105,7 +105,7 @@ func privateKeyAndCertificate(config *CertConfig, caCertBytes, caKeyBytes []byte
 	// verify the existing certs if valid use
 	cert, key, err := validCerts(config.ExistingCert, config.ExistingKey)
 	if err == nil {
-		zap.S().Infof("Reusing existing certs for %s", config.CommonName)
+		zap.S().Debugf("Reusing existing certs for %s", config.CommonName)
 		return cert, key, nil
 	}
 	// create private key, defaults to x509.RSA

--- a/operator/pkg/utils/patch/patch.go
+++ b/operator/pkg/utils/patch/patch.go
@@ -1,0 +1,56 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+)
+
+// PodSpec will merge the patch with the default pod spec and return the merged podSpec object
+func PodSpec(defaultSpec, patch *v1.PodSpec) (v1.PodSpec, error) {
+	if patch == nil {
+		return *defaultSpec, nil
+	}
+	obj := v1.PodSpec{}
+	mergedPatch, err := mergePatch(defaultSpec, patch, obj)
+	if err != nil {
+		return v1.PodSpec{}, err
+	}
+	result := &v1.PodSpec{}
+	if err := json.Unmarshal(mergedPatch, result); err != nil {
+		return v1.PodSpec{}, fmt.Errorf("unmarshalling merged patch to podSpec, %w", err)
+	}
+	return *result, nil
+}
+
+func mergePatch(defaultObj, patch, object interface{}) ([]byte, error) {
+	defaultSpecBytes, err := json.Marshal(defaultObj)
+	if err != nil {
+		return nil, err
+	}
+	patchSpecBytes, err := json.Marshal(patch)
+	if err != nil {
+		return nil, err
+	}
+	patchedBytes, err := strategicpatch.StrategicMergePatch(defaultSpecBytes, patchSpecBytes, object)
+	if err != nil {
+		return nil, fmt.Errorf("json merge patch, %w", err)
+	}
+	return patchedBytes, nil
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update ETCD spec to remove replicas field, as we won't be supporting updating the replica count for etcd cluster.
- Adds stateful set spec for etcd cluster creation.
Tested the cluster comes up by running the following commands in an etcd pod -

```
sh-4.2# ETCDCTL_API=3 etcdctl --endpoints=example-etcd.default.svc.cluster.local:2379 --cacert=/etc/kubernetes/pki/ca.crt --cert=/etc/kubernetes/pki/etcd/server/server.crt --key=/etc/kubernetes/pki/etcd/server/server.key member list -w table
+------------------+---------+----------------+--------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------+
|        ID        | STATUS  |      NAME      |                             PEER ADDRS                             |                                                      CLIENT ADDRS                                                      | IS LEARNER |
+------------------+---------+----------------+--------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------+
| 85c52305520b53a9 | started | example-etcd-2 | https://example-etcd-2.example-etcd.default.svc.cluster.local:2380 | https://example-etcd-2.example-etcd.default.svc.cluster.local:2379,https://example-etcd.default.svc.cluster.local:2379 |      false |
| dc9e0f5331df911b | started | example-etcd-0 | https://example-etcd-0.example-etcd.default.svc.cluster.local:2380 | https://example-etcd-0.example-etcd.default.svc.cluster.local:2379,https://example-etcd.default.svc.cluster.local:2379 |      false |
| f9fb2447635a312f | started | example-etcd-1 | https://example-etcd-1.example-etcd.default.svc.cluster.local:2380 | https://example-etcd-1.example-etcd.default.svc.cluster.local:2379,https://example-etcd.default.svc.cluster.local:2379 |      false |
+------------------+---------+----------------+--------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+------------+
```
```
sh-4.2# ETCDCTL_API=3 etcdctl --endpoints=example-etcd.default.svc.cluster.local:2379 --cacert=/etc/kubernetes/pki/ca.crt --cert=/etc/kubernetes/pki/etcd/server/server.crt --key=/etc/kubernetes/pki/etcd/server/server.key endpoint status -w table
+---------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
|                  ENDPOINT                   |        ID        | VERSION | DB SIZE | IS LEADER | IS LEARNER | RAFT TERM | RAFT INDEX | RAFT APPLIED INDEX | ERRORS |
+---------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
| example-etcd.default.svc.cluster.local:2379 | dc9e0f5331df911b |  3.4.14 |   20 kB |      true |      false |        35 |          9 |                  9 |        |
+---------------------------------------------+------------------+---------+---------+-----------+------------+-----------+------------+--------------------+--------+
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
