### PR TITLE
Host helm charts in repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
           ARCH=x86_64
           curl -L https://github.com/google/ko/releases/download/v${VERSION}/ko_${VERSION}_${OS}_${ARCH}.tar.gz | tar xzf - ko
           chmod +x ./ko
-          mv ko ~/go/bin/
+          mv ko /usr/local/bin/
       - name: Push to ECR public
         run: |
           make publish

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release operator version, generates a new Docker image and helm charts
 on:
-  release:
-    types: [published, created, edited] 
+  push:
+    tags: ['v*']
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,6 @@ name: Release operator version, generates a new Docker image and helm charts
 on:
   push:
     branches: [charts]
-  push:
     tags: ['v*']
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Build and test operator images on push to every branch except main and pull requests
+name: Release operator version, generates a new Docker image and helm charts
 on:
   push:
     branches: [charts]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Build and test operator images on push to every branch except main and pull requests
+on:
+  push:
+    branches: [charts]
+  push:
+    tags: ['v*']
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin/
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        env:
+          AWS_REGION: us-east-1
+      - name: Install KO binary
+        run: |
+          VERSION=0.8.3
+          OS=Linux
+          ARCH=x86_64
+          curl -L https://github.com/google/ko/releases/download/v${VERSION}/ko_${VERSION}_${OS}_${ARCH}.tar.gz | tar xzf - ko
+          chmod +x ./ko
+          mv ko ~/go/bin/
+      - name: Push to ECR public
+        run: |
+          make publish
+        working-directory: operator
+      - run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - uses: helm/chart-releaser-action@v1.1.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
 name: Release operator version, generates a new Docker image and helm charts
 on:
-  push:
-    branches: [charts]
-    tags: ['v*']
+  release:
+    types: [published, created, edited] 
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,5 +40,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       - uses: helm/chart-releaser-action@v1.1.0
+        with:
+          charts_dir: operator/charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -68,7 +68,6 @@ docs:
 		-template-dir $(shell go env GOMODCACHE)/github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0/template
 
 publish: ## Generate release manifests and publish a versioned container image.
-	@aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(RELEASE_REPO)
 	yq e -i ".controller.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-operator ko publish --bare -t $(RELEASE_VERSION) ./cmd/controller)\"" charts/kit-operator/values.yaml
 	yq e -i ".webhook.image = \"$$(KO_DOCKER_REPO=$(CONTAINER_IMAGE_REGISTRY)/kit $(WITH_GOFLAGS) ko publish -B -t $(RELEASE_VERSION) ./cmd/webhook)\"" charts/kit-operator/values.yaml
 	yq e -i '.version = "$(subst v,,${RELEASE_VERSION})"' charts/kit-operator/Chart.yaml

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -69,7 +69,9 @@ docs:
 
 publish: ## Generate release manifests and publish a versioned container image.
 	@aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin $(RELEASE_REPO)
-	KO_DOCKER_REPO=$(WITH_RELEASE_REPO) ko publish --bare ./cmd/controller
+	yq e -i ".controller.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-operator ko publish --bare -t $(RELEASE_VERSION) ./cmd/controller)\"" charts/kit-operator/values.yaml
+	yq e -i ".webhook.image = \"$$(KO_DOCKER_REPO=$(CONTAINER_IMAGE_REGISTRY)/kit $(WITH_GOFLAGS) ko publish -B -t $(RELEASE_VERSION) ./cmd/webhook)\"" charts/kit-operator/values.yaml
+	yq e -i '.version = "$(subst v,,${RELEASE_VERSION})"' charts/kit-operator/Chart.yaml
 
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,4 +1,3 @@
-
 RELEASE_REPO ?= public.ecr.aws/i7d3g4r4/kit-operator
 RELEASE_VERSION ?= $(shell git describe --tags --always)
 

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -1,3 +1,4 @@
+
 RELEASE_REPO ?= public.ecr.aws/i7d3g4r4/kit-operator
 RELEASE_VERSION ?= $(shell git describe --tags --always)
 
@@ -69,7 +70,7 @@ docs:
 
 publish: ## Generate release manifests and publish a versioned container image.
 	yq e -i ".controller.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-operator ko publish --bare -t $(RELEASE_VERSION) ./cmd/controller)\"" charts/kit-operator/values.yaml
-	yq e -i ".webhook.image = \"$$(KO_DOCKER_REPO=$(CONTAINER_IMAGE_REGISTRY)/kit $(WITH_GOFLAGS) ko publish -B -t $(RELEASE_VERSION) ./cmd/webhook)\"" charts/kit-operator/values.yaml
+	yq e -i ".webhook.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-webhook ko publish --bare -t $(RELEASE_VERSION) ./cmd/webhook)\"" charts/kit-operator/values.yaml
 	yq e -i '.version = "$(subst v,,${RELEASE_VERSION})"' charts/kit-operator/Chart.yaml
 
 toolchain: ## Install developer toolchain


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the capability to host helm charts in the repo-
- Once a new tag (v0.0.0 format) is pushed to the repo.
- Actions will build and push the release images tagged with git tag pushed
- Actions will also generate the Helm charts and cut a release with these charts, update index.yaml file hosted in `gh-pages` branch in the repo.

Once this is merged, users will be able to install KIT operator by running the following commands-
```
helm repo add kitrepo https://awslabs.github.io/kubernetes-iteration-toolkit/
helm search repo kit
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
