### PR TITLE
mega vpc to support kit clusters

### DIFF
--- a/testbed/addons/flux/construct.ts
+++ b/testbed/addons/flux/construct.ts
@@ -35,7 +35,7 @@ export class Flux extends cdk.Construct {
                     // we can adjust this later if we want to be more aggressive
                     interval: '5m0s',
                     ref: {
-                        branch: value.branch ?? "testbed",
+                        branch: value.branch ?? "main",
                     },
                     secretRef: {
                         name: 'github-key'

--- a/testbed/stack.ts
+++ b/testbed/stack.ts
@@ -14,8 +14,50 @@ export class Testbed extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string, props: TestbedProps) {
         super(scope, id)
 
-        const vpc = new ec2.Vpc(this, 'vpc', {})
+        const vpc = new ec2.Vpc(this, id, {
+            cidr: '10.0.0.0/16',
+            maxAzs: 99,
+            subnetConfiguration: [
+                {
+                    name: 'pub-subnet-1',
+                    subnetType: ec2.SubnetType.PUBLIC,
+                    cidrMask: 28,
+                },
+                {
+                    name: 'priv-subnet-1',
+                    subnetType: ec2.SubnetType.PRIVATE_WITH_NAT,
+                    cidrMask: 28,
+                },
+            ],
+        });
+        //ToDo: revisit once this is resolved - https://github.com/aws/aws-cdk/issues/5927
+        // index<=8 will give us 9  /16 cidrs additionally to make a mega VPC.
+        for (let index = 0; index <= 8; index++) {
+            let additionalCidr = new ec2.CfnVPCCidrBlock(this, `${id}-cidr-${index}`, {
+                vpcId: vpc.vpcId,
+                cidrBlock: `10.${index + 1}.0.0/16`
+            });
+            let privateSubnet = new ec2.PrivateSubnet(this, `${id}-private-subnet-${index}`, {
+                availabilityZone: cdk.Stack.of(this).availabilityZones[index%cdk.Stack.of(this).availabilityZones.length],
+                vpcId: vpc.vpcId,
+                cidrBlock: `10.${index + 1}.0.0/16`
+            })
+            privateSubnet.node.addDependency(additionalCidr);
 
+            ec2.NatProvider.gateway().configureNat({
+                natSubnets: [
+                    new ec2.PublicSubnet(this, `${id}-nat-subnet-${index}`, {
+                        availabilityZone: cdk.Stack.of(this).availabilityZones[index%cdk.Stack.of(this).availabilityZones.length],
+                        vpcId: vpc.vpcId,
+                        cidrBlock: `10.0.64.${index*16}/28`
+                    })
+                ],
+                privateSubnets: [
+                    privateSubnet
+                ],
+                vpc: vpc
+            })
+        }
         const cluster = new eks.Cluster(this, 'cluster', {
             clusterName: id,
             vpc: vpc,
@@ -33,7 +75,7 @@ export class Testbed extends cdk.Stack {
         cluster.addNodegroupCapacity('node-group', {
             nodegroupName: 'default',
             subnets: vpc.selectSubnets({
-                subnetType: ec2.SubnetType.PRIVATE
+                subnetType: ec2.SubnetType.PRIVATE_WITH_NAT
             }),
             nodeRole: new iam.Role(this, 'node-role', {
                 assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- need mega VPC on the host cluster to support KIT clusters as part of same VPC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
