### PR TITLE
Remove cluster name from IAM resources

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -30,8 +30,7 @@ KIT uses the [operator pattern](https://kubernetes.io/docs/concepts/extend-kuber
   aws cloudformation deploy  \
   --template-file docs/kit.cloudformation.yaml \
   --capabilities CAPABILITY_NAMED_IAM \
-  --stack-name kitControllerPolicy \
-  --parameter-overrides ClusterName=${SUBSTRATE_CLUSTER_NAME}
+  --stack-name kitControllerPolicy
 ```
 
 #### Associate the policy we just created to the kit-controller service account 
@@ -41,7 +40,7 @@ KIT uses the [operator pattern](https://kubernetes.io/docs/concepts/extend-kuber
     --name kit-controller \
     --namespace kit \
     --cluster ${SUBSTRATE_CLUSTER_NAME} \
-    --attach-policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/KitControllerPolicy-${SUBSTRATE_CLUSTER_NAME}-cluster \
+    --attach-policy-arn arn:aws:iam::${AWS_ACCOUNT_ID}:policy/KitControllerPolicy \
     --approve \
     --override-existing-serviceaccounts \
     --region=${AWS_REGION}

--- a/operator/docs/kit.cloudformation.yaml
+++ b/operator/docs/kit.cloudformation.yaml
@@ -1,21 +1,17 @@
 AWSTemplateFormatVersion: "2010-09-09"
 Description: Resources used by https://github.com/awslabs/kit/operator
-Parameters:
-  ClusterName:
-    Type: String
-    Description: "Desired cluster name"
 Resources:
   KitNodeInstanceProfile:
     Type: "AWS::IAM::InstanceProfile"
     Properties:
-      InstanceProfileName: !Sub "KitNodeInstanceProfile-${ClusterName}"
+      InstanceProfileName: "KitNodeInstanceProfile"
       Path: "/"
       Roles:
         - Ref: "KitNodeRole"
   KitNodeRole:
     Type: "AWS::IAM::Role"
     Properties:
-      RoleName: !Sub "KitNodeRole-${ClusterName}-cluster"
+      RoleName: "KitNodeRole"
       Path: /
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -34,7 +30,7 @@ Resources:
   KitControllerPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
-      ManagedPolicyName: !Sub "KitControllerPolicy-${ClusterName}-cluster"
+      ManagedPolicyName: "KitControllerPolicy"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/operator/pkg/awsprovider/launchtemplate/reconciler.go
+++ b/operator/pkg/awsprovider/launchtemplate/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	cpv1alpha1 "github.com/awslabs/kit/operator/pkg/apis/controlplane/v1alpha1"
@@ -119,7 +120,7 @@ func (c *Controller) createLaunchTemplate(ctx context.Context, dataplane *v1alph
 			InstanceType: ptr.String("t2.xlarge"), // TODO get this from dataplane spec
 			ImageId:      ptr.String(amiID),
 			IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
-				Name: ptr.String(fmt.Sprintf("KitNodeInstanceProfile-%s", dataplane.Spec.ClusterName)),
+				Name: aws.String(fmt.Sprintf("KitNodeInstanceProfile")),
 			},
 			Monitoring:       &ec2.LaunchTemplatesMonitoringRequest{Enabled: ptr.Bool(true)},
 			SecurityGroupIds: []*string{ptr.String(securityGroupID)},

--- a/operator/pkg/controllers/master/authenticatorconfig.go
+++ b/operator/pkg/controllers/master/authenticatorconfig.go
@@ -164,7 +164,7 @@ data:
         - groups:
           - system:bootstrappers
           - system:nodes
-          rolearn: arn:aws:iam::{{ .AWSAccountID }}:role/KitNodeRole-{{ .ClusterName }}-cluster
+          rolearn: arn:aws:iam::{{ .AWSAccountID }}:role/KitNodeRole
           username: system:node:{{ .PrivateDNS}}
       # List of Account IDs to whitelist for authentication
       mapAccounts:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes the cluster name from IAM resources which were making them host cluster specific. IAM resources needs to be referenced by KIT operator code and the host cluster name is not available. Also these resources don't need to be cluster specific and can be reused across clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
