### PR TITLE
CoreDNS, authenticator and pod spec merge fix

### DIFF
--- a/operator/pkg/controllers/addons/coredns.go
+++ b/operator/pkg/controllers/addons/coredns.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	clusterIP = "10.96.0.10" // TODO hard coded for now fix this
+	clusterIP = "10.100.0.10" // TODO hard coded for now fix this
 )
 
 type CoreDNS struct {
@@ -81,6 +81,10 @@ func (c *CoreDNS) clusterRole(ctx context.Context) error {
 			APIGroups: []string{""},
 			Resources: []string{"nodes"},
 			Verbs:     []string{"get"},
+		}, {
+			APIGroups: []string{"discovery.k8s.io"},
+			Resources: []string{"endpointslices"},
+			Verbs:     []string{"list", "watch"},
 		}},
 	})
 }
@@ -189,6 +193,7 @@ func (c *CoreDNS) deployment(ctx context.Context) error {
 					Labels: coreDNSLabels(),
 				},
 				Spec: v1.PodSpec{
+					DNSPolicy:          v1.DNSDefault,
 					PriorityClassName:  "system-cluster-critical",
 					ServiceAccountName: "coredns",
 					Containers: []v1.Container{{

--- a/operator/pkg/controllers/master/authenticatorconfig.go
+++ b/operator/pkg/controllers/master/authenticatorconfig.go
@@ -37,12 +37,13 @@ func (c *Controller) reconcileAuthenticatorConfig(ctx context.Context, controlPl
 	if err != nil {
 		return fmt.Errorf("getting AWS account ID, %w", err)
 	}
-	configMapBytes, err := ParseTemplate(authenticatorConfig, struct{ ClusterName, Namespace, Group, AWSAccountID, PrivateDNS string }{
+	configMapBytes, err := ParseTemplate(authenticatorConfig, struct{ ClusterName, Namespace, Group, AWSAccountID, PrivateDNS, SessionName string }{
 		ClusterName:  controlPlane.ClusterName(),
 		Namespace:    controlPlane.Namespace,
 		Group:        v1alpha1.SchemeGroupVersion.Group,
 		AWSAccountID: awsAccountID,
 		PrivateDNS:   "{{EC2PrivateDNSName}}",
+		SessionName:  "{{SessionNameRaw}}",
 	})
 	if err != nil {
 		return fmt.Errorf("generating authenticator config, %w", err)
@@ -166,6 +167,11 @@ data:
           - system:nodes
           rolearn: arn:aws:iam::{{ .AWSAccountID }}:role/KitNodeRole-{{ .ClusterName }}-cluster
           username: system:node:{{ .PrivateDNS}}
+        - groups:
+          - system:bootstrappers
+          - system:nodes
+          rolearn: arn:aws:iam::{{ .AWSAccountID }}:role/KitletNodeRole
+          username: system:node:{{ .SessionName }}
       # List of Account IDs to whitelist for authentication
       mapAccounts:
         - {{ .AWSAccountID }}

--- a/operator/pkg/controllers/master/kubescheduler.go
+++ b/operator/pkg/controllers/master/kubescheduler.go
@@ -22,36 +22,42 @@ import (
 	"github.com/awslabs/kit/operator/pkg/apis/controlplane/v1alpha1"
 	"github.com/awslabs/kit/operator/pkg/utils/imageprovider"
 	"github.com/awslabs/kit/operator/pkg/utils/object"
+	"github.com/awslabs/kit/operator/pkg/utils/patch"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (c *Controller) reconcileScheduler(ctx context.Context, controlPlane *v1alpha1.ControlPlane) error {
-	return c.kubeClient.EnsurePatch(ctx, &appsv1.Deployment{}, object.WithOwner(controlPlane, schedulerDeploymentSpec(controlPlane)))
-}
-
-func schedulerDeploymentSpec(controlPlane *v1alpha1.ControlPlane) *appsv1.Deployment {
-	return &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      SchedulerDeploymentName(controlPlane.ClusterName()),
-			Namespace: controlPlane.Namespace,
-		},
-		Spec: appsv1.DeploymentSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: schedulerLabels(controlPlane.ClusterName()),
-			},
-			Replicas: aws.Int32(3),
-			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: schedulerLabels(controlPlane.ClusterName()),
-				},
-				Spec: *schedulerPodSpecFor(controlPlane),
-			},
-		},
+func (c *Controller) reconcileScheduler(ctx context.Context, controlPlane *v1alpha1.ControlPlane) (err error) {
+	schedulerPodSpec := schedulerPodSpecFor(controlPlane)
+	if controlPlane.Spec.Master.Scheduler != nil {
+		schedulerPodSpec, err = patch.PodSpec(&schedulerPodSpec, controlPlane.Spec.Master.Scheduler.Spec)
+		if err != nil {
+			return fmt.Errorf("patch scheduler pod spec, %w", err)
+		}
 	}
+	return c.kubeClient.EnsurePatch(ctx, &appsv1.Deployment{},
+		object.WithOwner(controlPlane, &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      SchedulerDeploymentName(controlPlane.ClusterName()),
+				Namespace: controlPlane.Namespace,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: schedulerLabels(controlPlane.ClusterName()),
+				},
+				Replicas: aws.Int32(3),
+				Strategy: appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType},
+				Template: v1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: schedulerLabels(controlPlane.ClusterName()),
+					},
+					Spec: schedulerPodSpec,
+				},
+			},
+		}),
+	)
 }
 
 func SchedulerDeploymentName(clusterName string) string {
@@ -64,9 +70,9 @@ func schedulerLabels(clustername string) map[string]string {
 	}
 }
 
-func schedulerPodSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
+func schedulerPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
-	return &v1.PodSpec{
+	return v1.PodSpec{
 		TerminationGracePeriodSeconds: aws.Int64(1),
 		HostNetwork:                   true,
 		DNSPolicy:                     v1.DNSClusterFirstWithHostNet,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix service IP, RBAC rules for CoreDNS
- Add kubelet role to authenticator config
- Add podspec merge functionality to KCM and scheduler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
