### PR TITLE
Fix charts to not create SA, testbed names

### DIFF
--- a/operator/charts/kit-operator/templates/controller/rbac.yaml
+++ b/operator/charts/kit-operator/templates/controller/rbac.yaml
@@ -1,9 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: {{ .Values.serviceAccount.name }}
-  namespace: {{ .Release.Namespace }}
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/operator/charts/kit-operator/templates/controller/serviceaccount.yaml
+++ b/operator/charts/kit-operator/templates/controller/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/operator/pkg/awsprovider/instances/reconciler.go
+++ b/operator/pkg/awsprovider/instances/reconciler.go
@@ -45,7 +45,7 @@ func NewController(ec2api *awsprovider.EC2, autoscaling *awsprovider.AutoScaling
 }
 
 func (c *Controller) Reconcile(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
-	asg, err := c.getAutoScalingGroup(ctx, AutoScalingGroupNameFor(dataplane.Spec.ClusterName))
+	asg, err := c.getAutoScalingGroup(ctx, AutoScalingGroupNameFor(dataplane))
 	if err != nil {
 		return fmt.Errorf("getting auto scaling group for %v, %w", dataplane.Spec.ClusterName, err)
 	}
@@ -61,14 +61,14 @@ func (c *Controller) Reconcile(ctx context.Context, dataplane *v1alpha1.DataPlan
 		return fmt.Errorf("ASG %v deletion in progress", asg.AutoScalingGroupName)
 	}
 	if err := c.updateAutoScalingGroup(ctx, dataplane, asg); err != nil {
-		return fmt.Errorf("updating auto scaling group %v, %w", AutoScalingGroupNameFor(dataplane.Spec.ClusterName), err)
+		return fmt.Errorf("updating auto scaling group %v, %w", AutoScalingGroupNameFor(dataplane), err)
 	}
 	return nil
 }
 
 func (c *Controller) Finalize(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
 	if _, err := c.autoscaling.DeleteAutoScalingGroupWithContext(ctx, &autoscaling.DeleteAutoScalingGroupInput{
-		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane.Spec.ClusterName)),
+		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane)),
 		ForceDelete:          ptr.Bool(true), // terminate all the nodes in the ASG
 	}); err != nil {
 		return fmt.Errorf("deleting auto scaling group, %w", err)
@@ -100,7 +100,7 @@ func (c *Controller) updateAutoScalingGroup(ctx context.Context, dataplane *v1al
 	}
 	zap.S().Infof("[%v] updating ASG %v", dataplane.Spec.ClusterName, *asg.AutoScalingGroupName)
 	_, err = c.autoscaling.UpdateAutoScalingGroupWithContext(ctx, &autoscaling.UpdateAutoScalingGroupInput{
-		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane.Spec.ClusterName)),
+		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane)),
 		DesiredCapacity:      ptr.Int64(int64(dataplane.Spec.NodeCount)),
 		VPCZoneIdentifier:    ptr.String(strings.Join(subnets, ",")),
 		MixedInstancesPolicy: &autoscaling.MixedInstancesPolicy{
@@ -121,7 +121,7 @@ func (c *Controller) createAutoScalingGroup(ctx context.Context, dataplane *v1al
 		return fmt.Errorf("failed to find private subnets for dataplane")
 	}
 	_, err = c.autoscaling.CreateAutoScalingGroupWithContext(ctx, &autoscaling.CreateAutoScalingGroupInput{
-		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane.Spec.ClusterName)),
+		AutoScalingGroupName: ptr.String(AutoScalingGroupNameFor(dataplane)),
 		DesiredCapacity:      ptr.Int64(int64(dataplane.Spec.NodeCount)),
 		MaxSize:              ptr.Int64(int64(1000)),
 		MinSize:              ptr.Int64(int64(0)),
@@ -243,8 +243,8 @@ func (c *Controller) subnetsForInstances(ctx context.Context, instanceIDs []stri
 	return result, nil
 }
 
-func AutoScalingGroupNameFor(clusterName string) string {
-	return fmt.Sprintf("kit-%s-cluster-dataplane", clusterName)
+func AutoScalingGroupNameFor(dataplane *v1alpha1.DataPlane) string {
+	return fmt.Sprintf("kit-%s-cluster-%s", dataplane.Spec.ClusterName, dataplane.Name)
 }
 
 func generateAutoScalingTags(clusterName string) []*autoscaling.Tag {

--- a/operator/pkg/awsprovider/instances/reconciler.go
+++ b/operator/pkg/awsprovider/instances/reconciler.go
@@ -244,7 +244,7 @@ func (c *Controller) subnetsForInstances(ctx context.Context, instanceIDs []stri
 }
 
 func AutoScalingGroupNameFor(dataplane *v1alpha1.DataPlane) string {
-	return fmt.Sprintf("kit-%s-cluster-%s", dataplane.Spec.ClusterName, dataplane.Name)
+	return fmt.Sprintf("kit/%s-cluster/%s", dataplane.Spec.ClusterName, dataplane.Name)
 }
 
 func generateAutoScalingTags(clusterName string) []*autoscaling.Tag {

--- a/testbed/bin/testbed.ts
+++ b/testbed/bin/testbed.ts
@@ -2,11 +2,13 @@
 import * as cdk from '@aws-cdk/core'
 import { Testbed } from '../stack'
 
-new Testbed(new cdk.App(), 'testbed', {
+new Testbed(new cdk.App(),
+    process.env.STACK_NAME, {
     env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: process.env.CDK_DEFAULT_REGION
     },
+    stackName: process.env.STACK_NAME,
     repositories: [
         { name: "testbed", url: "https://github.com/awslabs/kubernetes-iteration-toolkit", path: "./testbed/addons" },
         { name: "tests", url: "https://github.com/awslabs/kubernetes-iteration-toolkit", path: "./tests" },

--- a/testbed/stack.ts
+++ b/testbed/stack.ts
@@ -11,8 +11,8 @@ export interface TestbedProps extends cdk.StackProps {
 }
 
 export class Testbed extends cdk.Stack {
-    constructor(scope: cdk.Construct, id: string, props: TestbedProps) {
-        super(scope, id)
+    constructor(scope: cdk.Construct, id: string="testbed", props: TestbedProps) {
+        super(scope, id, props)
 
         const vpc = new ec2.Vpc(this, id, {
             cidr: '10.0.0.0/16',


### PR DESCRIPTION
*Description of changes:*
- Fix create service account issue when deploying testbed, SA already exists and charts should skip creating it.
- We should be able to create testbeds with different names, after this fix we can deploy like this-
```
STACK_NAME=prateek-testbed cdk deploy --profile=eks-scalability-dev
```
- Map autoscaling group to Dataplane spec request.
  
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
