### PR TITLE
undo passing props as it's not compatible with existing resources that are already created

### DIFF
--- a/testbed/stack.ts
+++ b/testbed/stack.ts
@@ -12,7 +12,7 @@ export interface TestbedProps extends cdk.StackProps {
 
 export class Testbed extends cdk.Stack {
     constructor(scope: cdk.Construct, id: string="testbed", props: TestbedProps) {
-        super(scope, id, props)
+        super(scope, id)
 
         const vpc = new ec2.Vpc(this, id, {
             cidr: '10.0.0.0/16',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- undo this line from this PR  - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/59/files#diff-0634c4f68fd38278b74a3c1457c186b41b766865cf1e039fbe473988d4faed0eR15

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
