### PR TITLE
IGW routes for KIT CP LB; Custom tags for KIT CP and DP;update karp; remove kitnoderole, instance profile;

### DIFF
--- a/testbed/addons/karpenter/construct.ts
+++ b/testbed/addons/karpenter/construct.ts
@@ -62,7 +62,7 @@ export class Karpenter extends cdk.Construct {
         const chart = props.cluster.addHelmChart('karpenter', {
             chart: 'karpenter',
             release: 'karpenter',
-            version: 'v0.3.1',
+            version: 'v0.4.1',
             repository: 'https://awslabs.github.io/karpenter/charts',
             namespace: namespace,
             createNamespace: false,
@@ -77,21 +77,5 @@ export class Karpenter extends cdk.Construct {
             }
         })
         chart.node.addDependency(ns)
-
-        // Default Provisioner
-        props.cluster.addManifest("default-provisioner", {
-            apiVersion: 'karpenter.sh/v1alpha3',
-            kind: 'Provisioner',
-            metadata: {
-                name: 'default',
-            },
-            spec: {
-                cluster: {
-                    name: props.cluster.clusterName,
-                    endpoint: props.cluster.clusterEndpoint,
-                },
-                ttlSecondsAfterEmpty: 30,
-            }
-        }).node.addDependency(chart)
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add IGW route for KIT CP APIServer AWS LB access 
- Add custom tags `kit/hostcluster: <cluster-name>-controlplane` tag for Karpenter to scale KIT CP
- Add custom tags `kit/hostcluster: <cluster-name>-dataplane` tag for KIT to discover and launch dataplane nodes
- Update Karp to 0.4.1 to for KIT compatibility
- Remove KITNodeRole and InstanceProfile from KIT addons construct, as we decided to move those resource creation to KIT operator.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
