### PR TITLE
fix bug introuced yesterday in PR-62

### DIFF
--- a/testbed/addons/karpenter/construct.ts
+++ b/testbed/addons/karpenter/construct.ts
@@ -77,5 +77,26 @@ export class Karpenter extends cdk.Construct {
             }
         })
         chart.node.addDependency(ns)
+
+        //Karp Provisioner for kit
+        props.cluster.addManifest("default-provisioner", {
+            apiVersion: 'karpenter.sh/v1alpha5',
+            kind: 'Provisioner',
+            metadata: {
+                name: 'default',
+            },
+            spec: {
+                provider: {
+                    cluster: {
+                        name: props.cluster.clusterName,
+                        endpoint: props.cluster.clusterEndpoint,
+                    },
+                    subnetSelector: {
+                        "kit/hostcluster": `${props.cluster.clusterName}-controlplane`
+                    }
+                },
+                ttlSecondsAfterEmpty: 30,
+            }
+        }).node.addDependency(chart)
     }
 }

--- a/testbed/addons/kit/construct.ts
+++ b/testbed/addons/kit/construct.ts
@@ -71,27 +71,5 @@ export class Kit extends cdk.Construct {
             }
         })
         chart.node.addDependency(ns)
-
-        //Karp Provisioner for kit
-        props.cluster.addManifest("default-provisioner", {
-            apiVersion: 'karpenter.sh/v1alpha5',
-            kind: 'Provisioner',
-            metadata: {
-                name: 'default',
-            },
-            spec: {
-                provider: {
-                    cluster: {
-                        name: props.cluster.clusterName,
-                        endpoint: props.cluster.clusterEndpoint,
-                    },
-                    subnetSelector: {
-                        "kit/hostcluster": `${props.cluster.clusterName}-controlplane`
-                    }
-                },
-                ttlSecondsAfterEmpty: 30,
-            }
-        })
-
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Karp provisioner is racing with Karp/KIT. This bug was introduced by removing this line 95 in the last PR - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/62/files#diff-4e02459236fc7ae1edac9466bfe85f7b2b2b8a4f51a652a2239f8291ebd62ee2L95


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
