### PR TITLE
increase default cidr to accommodate all default host controller pods.

### DIFF
--- a/testbed/stack.ts
+++ b/testbed/stack.ts
@@ -21,12 +21,12 @@ export class Testbed extends cdk.Stack {
                 {
                     name: 'pub-subnet-1',
                     subnetType: ec2.SubnetType.PUBLIC,
-                    cidrMask: 28,
+                    cidrMask: 24,
                 },
                 {
                     name: 'priv-subnet-1',
                     subnetType: ec2.SubnetType.PRIVATE_WITH_NAT,
-                    cidrMask: 28,
+                    cidrMask: 24,
                 },
             ],
         });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- /28 is not enough to accommodate pods like KIT. This will become a problem as we add more addons to the testbed anyway, so moved to /24.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
