### PR TITLE
make copy/paste work for heredocs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Issue #, if available:
+
+Description of changes:
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

--- a/operator/README.md
+++ b/operator/README.md
@@ -65,7 +65,7 @@ Once KIT operator is deployed in a Kubernetes cluster. You can create a new Kube
   metadata:
     name: ${GUEST_CLUSTER_NAME} # Desired Cluster name
   spec: {}
-  EOF
+EOF
 ```
 
 2. Get the admin KUBECONFIG for the guest cluster from the substrate cluster
@@ -84,7 +84,7 @@ Once KIT operator is deployed in a Kubernetes cluster. You can create a new Kube
 
 4. Provision worker nodes for the guest cluster
 
-```
+```bash
   cat <<EOF | kubectl apply -f -
   apiVersion: kit.k8s.sh/v1alpha1
   kind: DataPlane
@@ -93,7 +93,7 @@ Once KIT operator is deployed in a Kubernetes cluster. You can create a new Kube
   spec: 
     clusterName: ${GUEST_CLUSTER_NAME} # Associated Cluster name
     nodeCount: 1
-  EOF
+EOF
 ```
 
 > TODO add instructions to be able to configure control plane parameters.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Make heredocs copy-able to the terminal. It currently doesn't work because there's a space in front of the ending `EOF` 
 - Add correct license in PR template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
