### PR TITLE
Support custom host-clustername for KIT tekton tasks; Tear down KIT clusters regardless of success/fail tests; Upgrade KIT to `0.0.4`

### DIFF
--- a/testbed/addons/kit/construct.ts
+++ b/testbed/addons/kit/construct.ts
@@ -67,7 +67,7 @@ export class Kit extends cdk.Construct {
         const chart = props.cluster.addHelmChart('kit', {
             chart: 'kit-operator',
             release: 'kit-operator',
-            version: '0.0.2',
+            version: '0.0.4',
             repository: 'https://awslabs.github.io/kubernetes-iteration-toolkit/',
             namespace: namespace,
             createNamespace: false,

--- a/tests/pipelines/kit/upstream-load.yaml
+++ b/tests/pipelines/kit/upstream-load.yaml
@@ -9,6 +9,9 @@ spec:
     - name: source
     - name: results
   params:
+  - name: host-cluster-name
+    description: The name of the Host cluster on which you spin up KIT Guest cluster.
+    default: "testbed"
   - name: cluster-name
     description: The name of the kit cluster you want to spin.
   - name: host-cluster-region
@@ -35,9 +38,9 @@ spec:
   - name: scheduler-qps
     default: "20"
     description: Kubernetes-Scheduler QPS setting
-  - name: node-count
+  - name: node_count
     default: "1000"
-    description: desired node count for Dataplane.
+    description: desired node count for Dataplane, min is 1000 to create DP nodes.
   - name: giturl
     description: "git url to clone the package"
     default: https://github.com/kubernetes/perf-tests.git
@@ -57,6 +60,8 @@ spec:
     taskRef:
       name: kit-cluster-create
     params:
+      - name: host-cluster-name
+        value: '$(params.host-cluster-name)'   
       - name: cluster-name
         value: '$(params.cluster-name)'
       - name: host-cluster-region
@@ -75,8 +80,8 @@ spec:
         value: '$(params.kcm-qps)' 
       - name: scheduler-qps
         value: '$(params.scheduler-qps)'
-      - name: node-count
-        value: '$(params.node-count)'      
+      - name: node_count
+        value: '$(params.node_count)'      
     workspaces:
       - name: config    
         workspace: config
@@ -96,7 +101,7 @@ spec:
       - name: results-bucket
         value: '$(params.results-bucket)'
       - name: nodes
-        value: '$(params.node-count)'
+        value: '$(params.node_count)'
     workspaces:
       - name: source
         workspace: source
@@ -104,10 +109,12 @@ spec:
         workspace: config
       - name: results
         workspace: results
+  finally:      
   - name: teardown
-    runAfter: [generate]
     taskRef:
       name: kit-cluster-teardown
     params:
+      - name: host-cluster-name
+        value: '$(params.host-cluster-name)'        
       - name: cluster-name
         value: '$(params.cluster-name)'

--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -42,13 +42,16 @@ spec:
       MEDIUM_STATEFUL_SETS_PER_NAMESPACE: 0
       # we are not testing PVS at this point
       CL2_ENABLE_PVS: false
+      PROMETHEUS_SCRAPE_APISERVER_ONLY: true
       PROMETHEUS_SCRAPE_KUBE_PROXY: false
       ENABLE_SYSTEM_POD_METRICS: false
       NODE_MODE: master 
       EOL
+      cat $(workspaces.source.path)/overrides.yaml
+      cp $(workspaces.source.path)/overrides.yaml $(workspaces.results.path)/overrides.yaml
   - name: validate-cluster
     image: amazon/aws-cli
-    workingDir: $(workspaces.source.path)
+    workingDir: $(workspaces.config.path)
     script: |
       mkdir -p /root/.kube/
       cp $(workspaces.config.path)/kubeconfig /root/.kube/config
@@ -63,19 +66,19 @@ spec:
       # end
   - name: run-loadtest
     image: 197575167141.dkr.ecr.us-west-2.amazonaws.com/clusterloader2:76e3fd7
-    command: ["./clusterloader"]
-    args: 
-    - --kubeconfig=$(workspaces.config.path)/kubeconfig
-    - --testconfig=$(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml
-    - --testoverrides=$(workspaces.source.path)/overrides.yaml
-    - --nodes=$(params.nodes) 
-    - --provider=eks 
-    - --report-dir=$(workspaces.results.path)
-    - --alsologtostderr
-    env:
-    - name: ENABLE_EXEC_SERVICE
-      value: "false"
+    script: |
+      ENABLE_EXEC_SERVICE=false ./clusterloader --kubeconfig=$(workspaces.config.path)/kubeconfig --testconfig=$(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path) --alsologtostderr
+      #To run the next step regardless of success/failure of the test
+      TEST_EXIT_CODE=$?
+      if [ $TEST_EXIT_CODE != 0 ]; then
+        exit 0
+      fi
+    timeout: 30000s
   - name: upload-results
     image: amazon/aws-cli
     workingDir: $(workspaces.results.path)
-    command: ["aws s3 cp . s3://$(params.results-bucket)/  --recursive "]
+    script: |
+      aws sts get-caller-identity
+      # we expect to see all files from loadtest that clusterloader2 outputs here in this dir
+      ls -larth
+      aws s3 cp . s3://$(params.results-bucket)/  --recursive

--- a/tests/tasks/setup/kit-cluster/default.yaml
+++ b/tests/tasks/setup/kit-cluster/default.yaml
@@ -9,6 +9,9 @@ spec:
     This Task can be used to create an KIT cluster in an AWS account and write a kubeconfig to a desired location that
     can be used by other tasks (in a context with kubectl) to make requests to the cluster.
   params:
+  - name: host-cluster-name
+    description: The name of the Host cluster on which you spin up KIT Guest cluster.
+    default: "testbed"
   - name: cluster-name
     description: The name of the KIT cluster you want to spin.
   - name: host-cluster-region
@@ -35,7 +38,7 @@ spec:
   - name: scheduler-qps
     default: "20"
     description: Kubernetes-Scheduler QPS setting
-  - name: node-count
+  - name: node_count
     default: "1000"
     description: desired node count for Dataplane.
   workspaces:
@@ -49,7 +52,7 @@ spec:
       curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
       install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       kubectl version
-      aws eks update-kubeconfig --name testbed --region $(params.host-cluster-region)
+      aws eks update-kubeconfig --name $(params.host-cluster-name) --region $(params.host-cluster-region)
       kubectl config current-context
       #Provision a control plane for the guest cluster
       cat > "$(workspaces.config.path)/cp.yaml" <<EOL
@@ -58,7 +61,7 @@ spec:
       metadata:
         name: $(params.cluster-name) # Desired Cluster Name
       spec:
-        kubernetesVersion: $(params.version)
+        kubernetesVersion: "$(params.version)"
         master:
           apiServer:
             spec:
@@ -81,25 +84,58 @@ spec:
               - name: scheduler
                 args:
                   - --kube-api-qps=$(params.scheduler-qps)
+        etcd:
+          spec:
+            nodeSelector: 
+              node.kubernetes.io/instance-type: $(params.cp-instance-type)
       EOL
+      aws sts get-caller-identity
+      #validate 
+      kubectl get pods -A
       kubectl create -f $(workspaces.config.path)/cp.yaml
-
-      cat > "$(workspaces.config.path)/dp.yaml" <<EOL
+      nodes=$(params.node_count)
+      asgs=$((nodes/1000))
+      asg_name=$(params.cluster-name)-nodes
+      create_dp()
+      {
+      cat > "$(workspaces.config.path)/dp$1"."yaml"<<EOL
       apiVersion: kit.k8s.sh/v1alpha1
       kind: DataPlane
       metadata:
-        name: $(params.cluster-name)-nodes 
+        name: "$asg_name-$1"
       spec: 
         clusterName: $(params.cluster-name) # Desired Cluster Name
-        nodeCount: $(params.node-count)
+        nodeCount: $2
+        subnetSelector:
+          kit/hostcluster: "$(params.host-cluster-name)-dataplane"
+        allocationStrategy: "flexible"
+        instanceTypes: #defaulting to nitro-instances for now
+          - m5.2xlarge
+          - m5.4xlarge
+          - m4.2xlarge
+          - m4.4xlarge
       EOL
-
       #Provision a dataplane plane for the guest cluster
-      kubectl create -f $(workspaces.config.path)/dp.yaml
-
+      ls -larth $(workspaces.config.path)
+      kubectl create -f "$(workspaces.config.path)/dp$1"."yaml"
+      }
+      for i in $(seq 1 $asgs)
+      do
+      #max number of nodes KIT operators allows per ASG
+      create_dp $i 1000 
+      done
+      remaining_nodes=$((nodes%1000))
+      create_dp 0 $remaining_nodes
+      # sleep for kude-admin config secret for kit guest cluster to appear
+      sleep 30
       #Get the admin KUBECONFIG for the guest cluster from the substrate cluster
       kubectl get secret $(params.cluster-name)-kube-admin-config -ojsonpath='{.data.config}' | base64 -d > $(workspaces.config.path)/kubeconfig
+      # wait for NLB APIServer endpoint to be available
+      sleep 300
       #Deploy CNI plugin to the guest cluster for the nodes to be ready.
       #Todo: CNI installation only works for `us-west-2`, yet to decide how to tackle other regions.
       kubectl --kubeconfig=$(workspaces.config.path)/kubeconfig apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.9/aws-k8s-cni.yaml
-      sleep 300
+      sleep 60
+      kubectl --kubeconfig=$(workspaces.config.path)/kubeconfig get pods -A 
+      # for nodes to become ready 
+      sleep $((nodes/6))

--- a/tests/tasks/teardown/kit.yaml
+++ b/tests/tasks/teardown/kit.yaml
@@ -13,12 +13,17 @@ spec:
   - name: region
     default: us-west-2
     description: The region where the EKS/host cluster is in.
+  - name: host-cluster-name
+    description: The name of the Host cluster on which you spin up KIT Guest cluster.
+    default: "testbed"
   steps:
   - name: delete-cluster
     image: amazon/aws-cli
     script: |
+      curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+      install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
       kubectl version
-      aws eks update-kubeconfig --name testbed --region $(params.region)
+      aws eks update-kubeconfig --name $(params.host-cluster-name) --region $(params.region)
       kubectl config current-context 
       #delete kit controlplane spec and dataplane spec crds
-      kubectl delete ControlPlane --name $(params.cluster-name)
+      kubectl delete controlplane $(params.cluster-name)

--- a/tests/triggers/eks/small/upstream-load.yaml
+++ b/tests/triggers/eks/small/upstream-load.yaml
@@ -4,7 +4,7 @@ kind: CronJob
 metadata:
   name: eks-small-upstream-load
 spec:
-  schedule: "0 8 * * *"
+  schedule: "0 0 1 * *"
   jobTemplate:
     spec:
       template:
@@ -58,4 +58,4 @@ spec:
       - name: cluster-name
         value: "eks-small-upstream-load-$(context.pipelineRun.uid)"
       - name: results-bucket
-        value: "eks-scalability-dev/$(date +'%Y/%m/%d/%HH/%mm)/$(context.pipelineRun.uid)"
+        value: "eks-scalability-dev/$(context.pipelineRun.uid)"

--- a/tests/triggers/kit/small/upstream-load.yaml
+++ b/tests/triggers/kit/small/upstream-load.yaml
@@ -31,7 +31,7 @@ spec:
       bindings:
       - ref: kit-small-upstream-load
       template:
-        ref: kit-small-upstream-load 
+        ref: kit-small-upstream-load
 ---
 apiVersion: triggers.tekton.dev/v1alpha1
 kind: TriggerTemplate
@@ -44,18 +44,25 @@ spec:
     metadata:
       generateName: kit-small-upstream-load-
     spec:
+      timeout: "9h0m0s"
       pipelineRef:
-        name: loadtest
+        name: kitloadtest
       serviceAccountName: test-executor
       workspaces:
       - name: source
         emptyDir: {}
       - name: config
-        emptyDir: {}
+        volumeClaimTemplate:
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi
       - name: results
         emptyDir: {}
       params:
       - name: cluster-name
-        value: "kit-small-upstream-load-$(context.pipelineRun.uid)"
+        value: "s$(context.pipelineRun.uid)"  #it's prefixed with 's' to identify cluster size is small.
       - name: results-bucket
-        value: "kit-scalability-dev/$(date +'%Y/%m/%d/%HH/%mm)/$(context.pipelineRun.uid)"
+        value: "kit-scalability/s$(context.pipelineRun.uid)"


### PR DESCRIPTION
- Update KIT to `0.0.4`
- Support custom host-clustername for KIT tekton tasks
- Tear down KIT clusters regardless of success/fail tests
- Adhere tekton to KIT requirements like wait for NLB creation, subnet-selectors etc (long standing changes on fork need to be merged

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
