### PR TITLE
Fix garbage collection in Kube 1.21

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -51,7 +51,7 @@ KIT uses the [operator pattern](https://kubernetes.io/docs/concepts/extend-kuber
 
 ```bash
    helm repo add kit https://awslabs.github.io/kubernetes-iteration-toolkit/
-   helm upgrade --install kit-operator kit/kit-operator --namespace kit --create-namespace --version 0.0.1
+   helm upgrade --install kit-operator kit/kit-operator --namespace kit --create-namespace --set serviceAccount.create=false
 ```
 
 Once KIT operator is deployed in a Kubernetes cluster. You can create a new Kubernetes control plane and worker nodes by following these steps in any namespace in the substrate cluster

--- a/operator/pkg/utils/object/object.go
+++ b/operator/pkg/utils/object/object.go
@@ -15,6 +15,8 @@ limitations under the License.
 package object
 
 import (
+	"fmt"
+
 	"github.com/awslabs/kit/operator/pkg/apis/controlplane/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,7 +30,7 @@ var (
 
 func WithOwner(owner, obj client.Object) client.Object {
 	obj.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: owner.GetObjectKind().GroupVersionKind().Version,
+		APIVersion: fmt.Sprintf("%s/%s", owner.GetObjectKind().GroupVersionKind().Group, owner.GetObjectKind().GroupVersionKind().Version),
 		Name:       owner.GetName(),
 		Kind:       owner.GetObjectKind().GroupVersionKind().Kind,
 		UID:        owner.GetUID(),

--- a/operator/pkg/utils/object/object.go
+++ b/operator/pkg/utils/object/object.go
@@ -15,8 +15,6 @@ limitations under the License.
 package object
 
 import (
-	"fmt"
-
 	"github.com/awslabs/kit/operator/pkg/apis/controlplane/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,7 +28,7 @@ var (
 
 func WithOwner(owner, obj client.Object) client.Object {
 	obj.SetOwnerReferences([]metav1.OwnerReference{{
-		APIVersion: fmt.Sprintf("%s/%s", owner.GetObjectKind().GroupVersionKind().Group, owner.GetObjectKind().GroupVersionKind().Version),
+		APIVersion: owner.GetObjectKind().GroupVersionKind().GroupVersion().String(),
 		Name:       owner.GetName(),
 		Kind:       owner.GetObjectKind().GroupVersionKind().Kind,
 		UID:        owner.GetUID(),


### PR DESCRIPTION
Issue #, if available:
Objects created with owner reference to control plane were not getting cleaned up in Kubernetes 1.21, I still need to validate in version 1.20

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
