### PR TITLE
Onboarding kube-controller-manager to in-tree Cloud Provider

### DIFF
--- a/operator/README.md
+++ b/operator/README.md
@@ -8,15 +8,15 @@ KIT uses the [operator pattern](https://kubernetes.io/docs/concepts/extend-kuber
 
 ## Getting started
 
-### Prerequisites
+### Overview
 
-- Kubernetes (substrate) Cluster
-- Following controller need to be installed in this cluster-
-  - [Karpenter controller](https://karpenter.sh/docs/getting-started/)
-  - [AWS Load balancer controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
+- Create a Kubernetes (substrate) Cluster
+- Install the AWS Load Balancer Controller
+- Install Karpenter
+- Install the KIT operator
 
-### Deploy KIT operator
 
+### Create a substrate cluster with eksctl
 ```bash
 SUBSTRATE_CLUSTER_NAME=kit-management-cluster
 GUEST_CLUSTER_NAME=example
@@ -24,8 +24,144 @@ AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 AWS_REGION=us-west-2
 ```
 
-#### Create an IAM role and policy which will be assumed by KIT operator to be able to talk AWS APIs
+This will create a substrate cluster with the necessary tags for Karpenter:
+```bash
+cat <<EOF > cluster.yaml
+---
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+metadata:
+  name: ${SUBSTRATE_CLUSTER_NAME}
+  region: ${AWS_REGION}
+  version: "1.21"
+  tags:
+    karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
+managedNodeGroups:
+  - instanceType: m5.large
+    amiFamily: AmazonLinux2
+    name: ${SUBSTRATE_CLUSTER_NAME}-ng
+    desiredCapacity: 1
+    minSize: 1
+    maxSize: 10
+iam:
+  withOIDC: true
+EOF
+eksctl create cluster -f cluster.yaml
+ ```
+### Install the AWS Load Balancer Controller
+- [AWS Load balancer controller](https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html)
 
+Create the IAM policy that will be attached to the IAM role used by the AWS Load Balancer Controller
+```bash
+curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.1/docs/install/iam_policy.json
+aws iam create-policy \
+    --policy-name AWSLoadBalancerControllerIAMPolicy \
+    --policy-document file://iam_policy.json
+```
+Create the IAM role and associate it to the load balancer controller service account.
+```bash
+eksctl create iamserviceaccount \
+  --cluster=${SUBSTRATE_CLUSTER_NAME} \
+  --namespace=kube-system \
+  --name=aws-load-balancer-controller \
+  --attach-policy-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/AWSLoadBalancerControllerIAMPolicy \
+  --override-existing-serviceaccounts \
+  --approve
+```
+Install the controller on your cluster.
+```bash
+helm repo add eks https://aws.github.io/eks-charts
+helm repo update
+helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  -n kube-system \
+  --set clusterName=${SUBSTRATE_CLUSTER_NAME} \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller 
+```
+
+### Install Karpenter on your cluster
+- [Karpenter controller](https://karpenter.sh/v0.5.5/getting-started/)
+
+Create the KarpenterNode IAM Role which has the necessary policies attached for Karpenter nodes. Additionally, we attach
+the AmazonEKSClusterPolicy to the KarpenterNode IAM role so that KCM pods running on these nodes have the necessary permissions
+to run the AWS Cloud Provider.
+```bash
+aws cloudformation deploy  \
+  --stack-name Karpenter-${SUBSTRATE_CLUSTER_NAME} \
+  --template-file docs/karpenter.cloudformation.yaml \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides ClusterName=${SUBSTRATE_CLUSTER_NAME}
+```
+Allow instances using the KarpenterNode IAM role to authenticate to your cluster.
+```bash
+eksctl create iamidentitymapping \
+  --username system:node:{{EC2PrivateDNSName}} \
+  --cluster ${SUBSTRATE_CLUSTER_NAME} \
+  --arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/KarpenterNodeRole-${SUBSTRATE_CLUSTER_NAME} \
+  --group system:bootstrappers \
+  --group system:nodes
+```
+Create the KarpenterController IAM Role and associate it to the karpenter service account with IRSA.
+```bash
+eksctl create iamserviceaccount \
+  --cluster $SUBSTRATE_CLUSTER_NAME --name karpenter --namespace karpenter \
+  --attach-policy-arn arn:aws:iam::$AWS_ACCOUNT_ID:policy/KarpenterControllerPolicy-$SUBSTRATE_CLUSTER_NAME \
+  --approve
+```
+Install the Karpenter Helm Chart.
+```bash
+helm repo add karpenter https://charts.karpenter.sh
+helm repo update
+helm upgrade --install karpenter karpenter/karpenter --namespace karpenter \
+  --create-namespace --set serviceAccount.create=false --version v0.5.5 \
+  --set controller.clusterName=${SUBSTRATE_CLUSTER_NAME} \
+  --set controller.clusterEndpoint=$(aws eks describe-cluster --name ${SUBSTRATE_CLUSTER_NAME} --query "cluster.endpoint" --output json) \
+  --wait # for the defaulting webhook to install before creating a Provisioner
+```
+#### Configure Karpenter provisioners to be able to provision the right kind of nodes
+Create the two following provisioners for Karpenter to be able to provisioner nodes for master and etcd
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: master-nodes
+spec:
+  labels:
+    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-apiserver
+    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
+  provider:
+    instanceProfile: KarpenterNodeInstanceProfile-${SUBSTRATE_CLUSTER_NAME}
+    subnetSelector:
+      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
+    securityGroupSelector:
+      kubernetes.io/cluster/${SUBSTRATE_CLUSTER_NAME}: owned
+  ttlSecondsAfterEmpty: 30
+EOF
+```
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
+metadata:
+  name: etcd-nodes
+spec:
+  labels:
+    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-etcd
+    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
+  provider:
+    instanceProfile: KarpenterNodeInstanceProfile-${SUBSTRATE_CLUSTER_NAME}
+    subnetSelector:
+      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
+    securityGroupSelector:
+      kubernetes.io/cluster/${SUBSTRATE_CLUSTER_NAME}: owned
+  ttlSecondsAfterEmpty: 30
+EOF
+```
+### Deploy KIT operator
+
+#### Create an IAM role and policy which will be assumed by KIT operator to be able to talk AWS APIs
 ```bash
 aws cloudformation deploy  \
   --template-file docs/kit.cloudformation.yaml \
@@ -53,50 +189,6 @@ eksctl create iamserviceaccount \
 helm repo add kit https://awslabs.github.io/kubernetes-iteration-toolkit/
 helm upgrade --install kit-operator kit/kit-operator --namespace kit --create-namespace --set serviceAccount.create=false
 ```
-
-#### Configure Karpenter provisioners to be able provision right kind of nodes 
-Create the two following provisioners for Karpenter to be able to provisioner nodes for master and etcd
-
-```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: karpenter.sh/v1alpha5
-kind: Provisioner
-metadata:
-  name: master-nodes
-spec:
-  labels:
-    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-apiserver
-    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
-  provider:
-    instanceProfile: KarpenterNodeInstanceProfile-${SUBSTRATE_CLUSTER_NAME}
-    subnetSelector:
-      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
-  ttlSecondsAfterEmpty: 30
-EOF
-```
-
-```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: karpenter.sh/v1alpha5
-kind: Provisioner
-metadata:
-  name: etcd-nodes
-spec:
-  labels:
-    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-etcd
-    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
-  provider:
-    instanceProfile: KarpenterNodeInstanceProfile-${SUBSTRATE_CLUSTER_NAME}
-    subnetSelector:
-      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
-    securityGroupSelector:
-      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
-  ttlSecondsAfterEmpty: 30
-EOF
-```
-
 Once KIT operator is deployed in a Kubernetes cluster. You can create a new Kubernetes control plane and worker nodes by following these steps in any namespace in the substrate cluster
 
 1. Provision a control plane for the guest cluster
@@ -121,7 +213,7 @@ kubectl get secret ${GUEST_CLUSTER_NAME}-kube-admin-config -ojsonpath='{.data.co
 3. Deploy CNI plugin to the guest cluster for the nodes to be ready. If you are deploying in `us-west-2` region run the following command to install AWS CNI plugin
 
 ```bash
-kubectl --kubeconfig=/tmp/kubeconfig apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.9/aws-k8s-cni.yaml
+kubectl --kubeconfig=/tmp/kubeconfig apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.10/config/master/aws-k8s-cni.yaml
 ```
 > For other regions, follow this guide to deploy the AWS CNI plugin- https://docs.aws.amazon.com/eks/latest/userguide/managing-vpc-cni.html
 
@@ -138,7 +230,23 @@ spec:
   nodeCount: 1
 EOF
 ```
+5. Optional: add a default EBS storage class to your KIT cluster.
 
+```bash
+cat <<EOF | kubectl --kubeconfig=/tmp/kubeconfig apply -f -
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gp2
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+  fsType: ext4
+volumeBindingMode: WaitForFirstConsumer
+EOF
+```
 > TODO add instructions to be able to configure control plane parameters.
 
 ---
@@ -152,3 +260,4 @@ eksctl delete iamserviceaccount --name kit-controller \
   --cluster ${SUBSTRATE_CLUSTER_NAME} \
   --region=$AWS_REGION
 ```
+

--- a/operator/docs/DEVELOPER_GUIDE.md
+++ b/operator/docs/DEVELOPER_GUIDE.md
@@ -12,12 +12,12 @@ If you are developing KIT operator, finish the installation steps listed in the 
 ### Create a [Private ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to push controller and webhook image for kit-operator
 
 ```bash
-    AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-    AWS_REGION=us-west-2
-    CONTAINER_IMAGE_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export AWS_REGION=us-west-2
+export CONTAINER_IMAGE_REGISTRY=${AWS_ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com
 
-    aws ecr create-repository --repository-name kit --region ${AWS_REGION}
-    aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin $CONTAINER_IMAGE_REGISTRY
+aws ecr create-repository --repository-name kit --region ${AWS_REGION}
+aws ecr get-login-password --region ${AWS_REGION} | docker login --username AWS --password-stdin $CONTAINER_IMAGE_REGISTRY
 ```
 
 ## Deploy
@@ -25,14 +25,14 @@ If you are developing KIT operator, finish the installation steps listed in the 
 Makefile calls `Ko` and `Ko` will build the Docker image and push the image to the container repo created in ECR in the last step. Once the image is published, Ko will `kubectl apply` KIT YAML(s) in `config` directory. This will install KIT operator and the required configs to the cluster listed in `kubectl config current-context`
 
 ```bash
-    kubectl create namespace kit
-    make apply
+kubectl create namespace kit
+make apply
 ```
 
 ## Delete KIT
 To delete KIT from Kubernetes cluster
 
 ```bash
-    make delete
-    kubectl delete namespace kit
+make delete
+kubectl delete namespace kit
 ```

--- a/operator/docs/karpenter.cloudformation.yaml
+++ b/operator/docs/karpenter.cloudformation.yaml
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Resources used by https://github.com/aws/karpenter
+Parameters:
+  ClusterName:
+    Type: String
+    Description: "Substrate cluster name"
+Resources:
+  KarpenterNodeInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      InstanceProfileName: !Sub "KarpenterNodeInstanceProfile-${ClusterName}"
+      Path: "/"
+      Roles:
+        - Ref: "KarpenterNodeRole"
+  KarpenterNodeRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: !Sub "KarpenterNodeRole-${ClusterName}"
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                !Sub "ec2.${AWS::URLSuffix}"
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSClusterPolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  KarpenterControllerPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: !Sub "KarpenterControllerPolicy-${ClusterName}"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Resource: "*"
+            Action:
+              # Write Operations
+              - ec2:CreateLaunchTemplate
+              - ec2:CreateFleet
+              - ec2:RunInstances
+              - ec2:CreateTags
+              - iam:PassRole
+              - ec2:TerminateInstances
+              # Read Operations
+              - ec2:DescribeLaunchTemplates
+              - ec2:DescribeInstances
+              - ec2:DescribeSecurityGroups
+              - ec2:DescribeSubnets
+              - ec2:DescribeInstanceTypes
+              - ec2:DescribeInstanceTypeOfferings
+              - ec2:DescribeAvailabilityZones
+              - ssm:GetParameter

--- a/operator/pkg/controllers/etcd/pod.go
+++ b/operator/pkg/controllers/etcd/pod.go
@@ -28,6 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	instanceTypeLabelKey          = "node.kubernetes.io/instance-type"
+	instanceTypeLabelDefaultValue = "m5.16xlarge"
+)
+
 func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 	return &v1.PodSpec{
 		TerminationGracePeriodSeconds: aws.Int64(1),
@@ -200,5 +205,5 @@ func caPeerName(controlPlane *v1alpha1.ControlPlane) string {
 
 func nodeSelector(clusterName string) map[string]string {
 	return functional.UnionStringMaps(labelsFor(clusterName),
-		map[string]string{object.ControlPlaneLabelKey: clusterName})
+		map[string]string{object.ControlPlaneLabelKey: clusterName, instanceTypeLabelKey: instanceTypeLabelDefaultValue})
 }

--- a/operator/pkg/controllers/master/master.go
+++ b/operator/pkg/controllers/master/master.go
@@ -55,6 +55,7 @@ func (c *Controller) Reconcile(ctx context.Context, controlPlane *v1alpha1.Contr
 		c.reconcileKubeConfigs,
 		c.reconcileSAKeyPair,
 		c.reconcileApiServer,
+		c.reconcileKCMCloudConfig,
 		c.reconcileKCM,
 		c.reconcileScheduler,
 		c.reconcileAuthenticatorConfig,


### PR DESCRIPTION
Description of changes:
Onboarding kube-controller-manager to in-tree Cloud Provider.

If the KIT control plane was running in a different account and VPC than its worker nodes, these three fields would be required in our KCM config.
```
[Global]
VPC=<vpc-id>
RoleArn=<arn>
KubernetesClusterID=<cluster-name>
```
Since we are running the KIT control plane in the same VPC as its worker nodes, only the KubernetesClusterId field is required.
```
[Global]
KubernetesClusterID=<cluster-name>
```
By not specifying a VPC ID, it is discovered from the metadata service on the control plane instance which is running KCM. By not specifying a RoleArn, we will use the default node instance credentials. As a result, we attached the AmazonEKSClusterPolicy IAM policy to our KarpenterNodeRole which runs the KCM pod. Note that we have to provide the KubernetesClusterId field because it would incorrectly be set to the name of the substrate cluster rather than the name of the KIT cluster. The KIT control plane nodes are worker nodes in the substrate cluster so this tag is applied to them:
```
kubernetes.io/cluster/<SUBSTATE-CLUSTER-NAME>: owned
```
As a result, the KubernetesClusterID field has to be set manually to correctly configure the cloud provider in KCM.

- Ref for VPC ID discovery: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L2333
- Ref for using default node role: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L1200
- Ref for how cluster name would be incorrectly discovered: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/tags.go#L112

One other requirement we have for the cloud provider to work on KIT clusters is that our subnets cannot be tagged with:
```
kubernetes.io/cluster/<SUBSTATE-CLUSTER-NAME> shared
```
After 1.19, EKS stopped automatically tagging subnets with this tag and it can optionally be used to control where ELBs created by the Cloud Provider are provisioned. If this tag is provided, no subnets would match the KIT cluster and the only subnet that could provision an ELB would be the current subnet for the instance hosting this instance of KCM. If the tag is not provided, all subnets in the VPC would be eligible to host the ELBs.

- Ref for ELB subnet discovery: https://github.com/kubernetes/kubernetes/blob/f5be5052e3d0808abb904aebd3218fe4a5c2dd82/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L3414

Testing:
1. Confirming the CloudConfig is correctly configured.
Checking content of KCM CloudConfig:
```
$ kubectl get configmap example-cloud-config -o yaml
apiVersion: v1
data:
  aws.config: |
    [Global]
    KubernetesClusterID=example
kind: ConfigMap
metadata:
...
```
KCM logs show CloudProvider is configured:
```
$ kubectl logs example-controller-manager-2zffx
...
W0127 23:13:33.274516       1 plugins.go:105] WARNING: aws built-in cloud provider is now deprecated. The AWS provider is deprecated and will be removed in a future release
I0127 23:13:33.274874       1 aws.go:1225] Zone not specified in configuration file; querying AWS metadata service
I0127 23:13:33.276204       1 aws.go:1265] Building AWS cloudprovider
I0127 23:13:33.435779       1 tags.go:79] AWS cloud filtering on ClusterID: example
```
2. Confirming that KCM removes node objects for terminated nodes:
Scaled down nodes in dataplane object and confirmed nodes objects were deleted by KCM:
```
W0128 00:49:37.239420       1 aws.go:1664] the instance i-0da37272e8eac993d is terminated
I0128 00:49:37.239573       1 event.go:291] "Event occurred" object="ip-192-168-159-139.us-west-2.compute.internal" kind="Node" apiVersion="" type="Normal" reason="Deleting node ip-192-168-159-139.us-west-2.compute.internal because it does not exist in the cloud provider" message="Node ip-192-168-159-139.us-west-2.compute.internal event: DeletingNode"
I0128 00:49:41.417478       1 event.go:291] "Event occurred" object="ip-192-168-159-139.us-west-2.compute.internal" kind="Node" apiVersion="v1" type="Normal" reason="RemovingNode" message="Node ip-192-168-159-139.us-west-2.compute.internal event: Removing Node ip-192-168-159-139.us-west-2.compute.internal from Controller"
```

3. Confirm we can provision a service of type LoadBalancer:
```
$ kubectl create deployment nginx --image nginx --replicas 10
deployment.apps/nginx created
$ kubectl expose deployment nginx --type LoadBalancer --port 80
service/nginx exposed
```
Confirmed that all subnets used in KIT dataplane ASG were used to provision the ELB and all instances were registered. Related KCM logs: 
```
I0128 00:04:08.986761       1 event.go:291] "Event occurred" object="default/nginx" kind="Service" apiVersion="v1" type="Normal" reason="EnsuredLoadBalancer" message="Ensured load balancer"
I0128 00:07:03.922658       1 event.go:291] "Event occurred" object="default/nginx" kind="Service" apiVersion="v1" type="Normal" reason="DeletingLoadBalancer" message="Deleting load balancer"
```
4. Testing aws-ebs StorageClass:
Create a PVC for a volume with 6Gi:
```
cat <<EOF | kubectl --kubeconfig=/tmp/kubeconfig apply -f -
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: myclaim
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 6Gi
EOF
```
Create a pod consumer for the PVC:
```
cat <<EOF | kubectl --kubeconfig=/tmp/kubeconfig apply -f -
kind: Pod
apiVersion: v1
metadata:
  name: mypod
spec:
  containers:
    - name: myfrontend
      image: nginx
      volumeMounts:
      - mountPath: "/var/www/html"
        name: mypd
  volumes:
    - name: mypd
      persistentVolumeClaim:
        claimName: myclaim
EOF
```
Volume provisioning:
```
I0128 00:20:31.790011       1 event.go:291] "Event occurred" object="default/myclaim" kind="PersistentVolumeClaim" apiVersion="v1" type="Normal" reason="ProvisioningSucceeded" message="Successfully provisioned volume pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e using kubernetes.io/aws-ebs"
I0128 00:20:32.346006       1 reconciler.go:295] attacherDetacher.AttachVolume started for volume "pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e" (UniqueName: "kubernetes.io/aws-ebs/aws://us-west-2b/vol-0f88346146884a68c") from node "ip-192-168-163-43.us-west-2.compute.internal"
I0128 00:20:35.064884       1 operation_generator.go:361] AttachVolume.Attach succeeded for volume "pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e" (UniqueName: "kubernetes.io/aws-ebs/aws://us-west-2b/vol-0f88346146884a68c") from node "ip-192-168-163-43.us-west-2.compute.internal"
I0128 00:20:35.065003       1 event.go:291] "Event occurred" object="default/mypod" kind="Pod" apiVersion="v1" type="Normal" reason="SuccessfulAttachVolume" message="AttachVolume.Attach succeeded for volume \"pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e\" "
```
Delete the consumer and PV object:
```
$ kubectl delete pod mypod
pod "mypod" deleted
$ kubectl delete pv pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e
persistentvolume "pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e" deleted
```
Checking detachment succeeded:
```
I0128 00:21:17.100505       1 operation_generator.go:1400] Verified volume is safe to detach for volume "pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e" (UniqueName: "kubernetes.io/aws-ebs/aws://us-west-2b/vol-0f88346146884a68c") on node "ip-192-168-163-43.us-west-2.compute.internal"
I0128 00:21:22.512092       1 operation_generator.go:472] DetachVolume.Detach succeeded for volume "pvc-2fb99c9c-08ad-476e-9d24-e2b4bf78ea7e" (UniqueName: "kubernetes.io/aws-ebs/aws://us-west-2b/vol-0f88346146884a68c") on node "ip-192-168-163-43.us-west-2.compute.internal"
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
