### PR TITLE
Add debug flag for CLI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,12 +70,12 @@ jobs:
         go-version: '1.17.1'
     - name: Build the KIT CLI
       run: |
-        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitcli ./cmd/
-        zip ./bin/kitcli_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip -j ./bin/kitcli
+        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitctl ./cmd/
+        zip ./bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip -j ./bin/kitctl
       working-directory: substrate
     - name: Attach the binary to release
       uses: softprops/action-gh-release@v1
       with:
-        files: "./substrate/bin/kitcli_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip"
+        files: "./substrate/bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/kitctl.rb
+++ b/kitctl.rb
@@ -1,16 +1,16 @@
 # Update the version and SHA256 for the CLI when new version is released
 require 'formula'
-class Kitcli < Formula
+class Kitctl < Formula
   homepage 'https://github.com/awslabs/kubernetes-iteration-toolkit/substrate'
   version '$VERSION'
   if OS.mac? && Hardware::CPU.is_64_bit?
-    url 'https://github.com/awslabs/kubernetes-iteration-toolkit/releases/download/$VERSION/kitcli_$VERSION_darwin_amd64.zip'
+    url 'https://github.com/awslabs/kubernetes-iteration-toolkit/releases/download/$VERSION/kitctl_$VERSION_darwin_amd64.zip'
     sha256 '$SHA256'
   else
     echo "Hardware not supported"
     exit 1
   end
   def install
-    bin.install 'kitcli'
+    bin.install 'kitctl'
   end
 end

--- a/substrate/README.md
+++ b/substrate/README.md
@@ -1,39 +1,106 @@
-# KITCLI
+# kitctl
 
-## Installing KITCLI
+## Installing kitctl
 
 ```bash
 brew tap awslabs/kit https://github.com/awslabs/kubernetes-iteration-toolkit.git
-brew install kitcli
+brew install kitctl
 ```
 
 ## Usage
+kitctl helps provision an AWS infrastructure environment to deploy Kubernetes clusters using kit-operator. It runs a single node kubernetes cluster in a VPC installed with all the required controllers like Karpeneter, KIT-operator, ELB controller and EBS CSI Driver to manage the lifecycle of clusters. kitctl also creates the necessary IAM permissions required for these controllers.
+To get started make sure you have admin access to AWS.
 
-```sh
-kitcli apply
-kitcli delete
+### Bootstrap an environment in AWS to run Kubernetes clusters using kit-operator
+
+```bash
+kitctl bootstrap
+```
+> Set KUBECONFIG to access the environment with the kubeconfig location provided from this command
+
+### Configure Karpenter to provision nodes for the Kubernetes cluster control plane
+
+```bash
+GUEST_CLUSTER_NAME=foo # Desired Cluster name
+SUBSTRATE_CLUSTER_NAME=test-substrate
 ```
 
-```shell
-cat <<EOF | kitcli apply -f -
-apiVersion: kit.sh/v1alpha1
-kind: Substrate
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
 metadata:
-  name: ${USER}
+  name: master-nodes
 spec:
-  instanceType: c5.2xlarge
----
-apiVersion: kit.sh/v1alpha1
-kind: Cluster
+  kubeletConfiguration:
+    clusterDNS:
+      - "10.96.0.10"
+  labels:
+    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-apiserver
+    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
+  provider:
+    instanceProfile: kit-${SUBSTRATE_CLUSTER_NAME}-tenant-controlplane-node-role
+    subnetSelector:
+      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
+    securityGroupSelector:
+      kubernetes.io/cluster/${SUBSTRATE_CLUSTER_NAME}: owned
+    tags:
+      kit.aws/substrate: ${SUBSTRATE_CLUSTER_NAME}
+  ttlSecondsAfterEmpty: 30
+EOF
+```
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: karpenter.sh/v1alpha5
+kind: Provisioner
 metadata:
-  name: ${USER}
+  name: etcd-nodes
+spec:
+  kubeletConfiguration:
+    clusterDNS:
+      - "10.96.0.10"
+  labels:
+    kit.k8s.sh/app: ${GUEST_CLUSTER_NAME}-etcd
+    kit.k8s.sh/control-plane-name: ${GUEST_CLUSTER_NAME}
+  provider:
+    instanceProfile: kit-${SUBSTRATE_CLUSTER_NAME}-tenant-controlplane-node-role
+    subnetSelector:
+      karpenter.sh/discovery: ${SUBSTRATE_CLUSTER_NAME}
+    securityGroupSelector:
+      kubernetes.io/cluster/${SUBSTRATE_CLUSTER_NAME}: owned
+    tags:
+      kit.aws/substrate: ${SUBSTRATE_CLUSTER_NAME}
+  ttlSecondsAfterEmpty: 30
+EOF
+EOF
+```
+
+### Provision a Kubernetes cluster control plane
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: kit.k8s.sh/v1alpha1
+kind: ControlPlane
+metadata:
+  name: ${GUEST_CLUSTER_NAME} # Desired Cluster name
 spec: {}
 EOF
-
-kitcli delete substrate ${USER}
 ```
 
-## Developing
+### cleanup
+
+- To remove the kubernetes cluster provisioned using kit-operator
+
+```bash
+kubectl delete controlplane ${GUEST_CLUSTER_NAME}
 ```
-alias kitcli="go run ./cmd"
+
+- To clean up the AWS environment
+
+```bash
+kitctl helps provision an AWS infrastructure environment to deploy Kubernetes clusters using kit-operator. It runs a single node kubernetes cluster with all the required controllers like Karpeneter, KIT-operator, ELB controller and EBS CSI Driver to manage the lifecycle of clusters. kitctl also creates the necessary delete
 ```
+
+### Debug logs
+Run the `kitctl helps provision an AWS infrastructure environment to deploy Kubernetes clusters using kit-operator. It runs a single node kubernetes cluster with all the required controllers like Karpeneter, KIT-operator, ELB controller and EBS CSI Driver to manage the lifecycle of clusters. kitctl also creates the necessary` commands with `--debug` flag

--- a/substrate/cmd/delete.go
+++ b/substrate/cmd/delete.go
@@ -24,18 +24,16 @@ import (
 	"knative.dev/pkg/logging"
 )
 
-func init() {
-	rootCmd.LocalFlags().StringVar(&options.File, "name", "", "Name for the environment")
-	rootCmd.LocalFlags().StringVarP(&options.File, "file", "f", "", "Configuration file for the environment")
-	rootCmd.AddCommand(&cobra.Command{
+func deleteCommand() *cobra.Command {
+	return &cobra.Command{
 		Use:   "delete",
 		Short: "Delete the environment",
 		Long:  ``,
-		Run:   Delete,
-	})
+		Run:   delete,
+	}
 }
 
-func Delete(cmd *cobra.Command, args []string) {
+func delete(cmd *cobra.Command, args []string) {
 	ctx := cmd.Context()
 	start := time.Now()
 	name := "test-substrate"
@@ -45,5 +43,5 @@ func Delete(cmd *cobra.Command, args []string) {
 		logging.FromContext(ctx).Error(err.Error())
 		return
 	}
-	logging.FromContext(ctx).Infof("Deleted substrate %s after %s", name, time.Since(start))
+	logging.FromContext(ctx).Debugf("Deleted substrate %s after %s", name, time.Since(start))
 }

--- a/substrate/cmd/delete.go
+++ b/substrate/cmd/delete.go
@@ -43,5 +43,5 @@ func delete(cmd *cobra.Command, args []string) {
 		logging.FromContext(ctx).Error(err.Error())
 		return
 	}
-	logging.FromContext(ctx).Debugf("Deleted substrate %s after %s", name, time.Since(start))
+	logging.FromContext(ctx).Infof("Deleted substrate %s after %s", name, time.Since(start))
 }

--- a/substrate/go.mod
+++ b/substrate/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/imdario/mergo v0.3.12
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/spf13/cobra v1.3.0
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/multierr v1.7.0
 	go.uber.org/zap v1.19.1
 	helm.sh/helm/v3 v3.8.0

--- a/substrate/go.sum
+++ b/substrate/go.sum
@@ -847,6 +847,7 @@ github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
 github.com/marstr/guid v1.1.0/go.mod h1:74gB1z2wpxxInTG6yaqA7KrtM0NZ+RbrcqDvYHefzho=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=

--- a/substrate/pkg/controller/substrate/cluster/addons/kubeproxy.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/kubeproxy.go
@@ -38,7 +38,7 @@ func (k *KubeProxy) Create(ctx context.Context, substrate *v1alpha1.Substrate) (
 	}
 	config := cluster.DefaultClusterConfig(substrate)
 	if err := proxy.EnsureProxyAddon(&config.ClusterConfiguration, &config.LocalAPIEndpoint, client); err != nil {
-		return reconcile.Result{Requeue: true}, fmt.Errorf("ensuring kube-proxy addon, %w", err)
+		return reconcile.Result{}, fmt.Errorf("ensuring kube-proxy addon, %w", err)
 	}
 	return reconcile.Result{}, nil
 }

--- a/substrate/pkg/controller/substrate/cluster/address.go
+++ b/substrate/pkg/controller/substrate/cluster/address.go
@@ -36,7 +36,7 @@ func (a *Address) Create(ctx context.Context, substrate *v1alpha1.Substrate) (re
 		return reconcile.Result{}, fmt.Errorf("describing addresses, %w", err)
 	}
 	if len(addressesOutput.Addresses) > 0 {
-		logging.FromContext(ctx).Infof("Found address %s", aws.StringValue(addressesOutput.Addresses[0].PublicIp))
+		logging.FromContext(ctx).Debugf("Found address %s", aws.StringValue(addressesOutput.Addresses[0].PublicIp))
 		substrate.Status.Cluster.Address = addressesOutput.Addresses[0].PublicIp
 		return reconcile.Result{}, nil
 	}

--- a/substrate/pkg/controller/substrate/cluster/config.go
+++ b/substrate/pkg/controller/substrate/cluster/config.go
@@ -103,8 +103,9 @@ func (c *Config) Create(ctx context.Context, substrate *v1alpha1.Substrate) (rec
 		aws.StringValue(discovery.Name(substrate)), path.Join(ClusterCertsBasePath, aws.StringValue(discovery.Name(substrate))))); err != nil {
 		return reconcile.Result{}, fmt.Errorf("uploading to S3 %w", err)
 	}
-	logging.FromContext(ctx).Infof("Uploaded cluster configuration to s3://%s", aws.StringValue(discovery.Name(substrate)))
+	logging.FromContext(ctx).Debugf("Uploaded cluster configuration to s3://%s", aws.StringValue(discovery.Name(substrate)))
 	substrate.Status.Cluster.KubeConfig = ptr.String(path.Join(ClusterCertsBasePath, aws.StringValue(discovery.Name(substrate)), kubeconfigFile))
+	logging.FromContext(ctx).Infof("To access substrate cluster, export KUBECONFIG=%s", aws.StringValue(substrate.Status.Cluster.KubeConfig))
 	return reconcile.Result{}, nil
 }
 
@@ -190,7 +191,7 @@ func (c *Config) ensureBucket(ctx context.Context, substrate *v1alpha1.Substrate
 		if err.(awserr.Error).Code() != s3.ErrCodeBucketAlreadyOwnedByYou {
 			return fmt.Errorf("creating S3 bucket, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found s3 bucket %s", aws.StringValue(discovery.Name(substrate)))
+		logging.FromContext(ctx).Debugf("Found s3 bucket %s", aws.StringValue(discovery.Name(substrate)))
 	} else {
 		logging.FromContext(ctx).Infof("Created s3 bucket %s", aws.StringValue(discovery.Name(substrate)))
 	}
@@ -292,7 +293,7 @@ func (c *Config) ensureAuthenticatorConfig(ctx context.Context, substrate *v1alp
 	if err != nil {
 		return fmt.Errorf("creating authenticator config, %w", err)
 	}
-	logging.FromContext(ctx).Infof("Created config map for authenticator")
+	logging.FromContext(ctx).Debugf("Created config map for authenticator")
 	configDir := path.Join(ClusterCertsBasePath, aws.StringValue(discovery.Name(substrate)), authenticatorConfigDir)
 	if err := os.MkdirAll(configDir, 0700); err != nil {
 		return fmt.Errorf("failed to create directory, %w", err)

--- a/substrate/pkg/controller/substrate/cluster/config.go
+++ b/substrate/pkg/controller/substrate/cluster/config.go
@@ -105,7 +105,7 @@ func (c *Config) Create(ctx context.Context, substrate *v1alpha1.Substrate) (rec
 	}
 	logging.FromContext(ctx).Debugf("Uploaded cluster configuration to s3://%s", aws.StringValue(discovery.Name(substrate)))
 	substrate.Status.Cluster.KubeConfig = ptr.String(path.Join(ClusterCertsBasePath, aws.StringValue(discovery.Name(substrate)), kubeconfigFile))
-	logging.FromContext(ctx).Infof("To access substrate cluster, export KUBECONFIG=%s", aws.StringValue(substrate.Status.Cluster.KubeConfig))
+	logging.FromContext(ctx).Infof("To access substrate cluster run -\n \texport KUBECONFIG=%s", aws.StringValue(substrate.Status.Cluster.KubeConfig))
 	return reconcile.Result{}, nil
 }
 

--- a/substrate/pkg/controller/substrate/cluster/instanceprofile.go
+++ b/substrate/pkg/controller/substrate/cluster/instanceprofile.go
@@ -63,7 +63,7 @@ func (i *InstanceProfile) create(ctx context.Context, resourceName, policy *stri
 		if err.(awserr.Error).Code() != iam.ErrCodeEntityAlreadyExistsException {
 			return reconcile.Result{}, fmt.Errorf("creating role, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found role %s", aws.StringValue(resourceName))
+		logging.FromContext(ctx).Debugf("Found role %s", aws.StringValue(resourceName))
 	} else {
 		logging.FromContext(ctx).Infof("Created role %s", aws.StringValue(resourceName))
 	}
@@ -79,14 +79,14 @@ func (i *InstanceProfile) create(ctx context.Context, resourceName, policy *stri
 		if _, err := i.IAM.AttachRolePolicyWithContext(ctx, &iam.AttachRolePolicyInput{RoleName: resourceName, PolicyArn: aws.String(policy)}); err != nil {
 			return reconcile.Result{}, fmt.Errorf("attaching role policy %w", err)
 		}
-		logging.FromContext(ctx).Infof("Ensured managed policy %s for %s", policy, aws.StringValue(resourceName))
+		logging.FromContext(ctx).Debugf("Ensured managed policy %s for %s", policy, aws.StringValue(resourceName))
 	}
 	// Profile
 	if _, err := i.IAM.CreateInstanceProfileWithContext(ctx, &iam.CreateInstanceProfileInput{InstanceProfileName: resourceName}); err != nil {
 		if err.(awserr.Error).Code() != iam.ErrCodeEntityAlreadyExistsException {
 			return reconcile.Result{}, fmt.Errorf("creating instance profile, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found instance profile %s", aws.StringValue(resourceName))
+		logging.FromContext(ctx).Debugf("Found instance profile %s", aws.StringValue(resourceName))
 	} else {
 		logging.FromContext(ctx).Infof("Created instance profile %s", aws.StringValue(resourceName))
 	}
@@ -95,7 +95,7 @@ func (i *InstanceProfile) create(ctx context.Context, resourceName, policy *stri
 		if err.(awserr.Error).Code() != iam.ErrCodeLimitExceededException {
 			return reconcile.Result{}, fmt.Errorf("adding role to instance profile, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found role %s on instance profile %s", aws.StringValue(resourceName), aws.StringValue(resourceName))
+		logging.FromContext(ctx).Debugf("Found role %s on instance profile %s", aws.StringValue(resourceName), aws.StringValue(resourceName))
 	} else {
 		logging.FromContext(ctx).Infof("Added role %s to instance profile %s", aws.StringValue(resourceName), aws.StringValue(resourceName))
 	}

--- a/substrate/pkg/controller/substrate/cluster/launchtemplate.go
+++ b/substrate/pkg/controller/substrate/cluster/launchtemplate.go
@@ -121,7 +121,7 @@ chmod a+x /etc/kit/sync.sh
 		if err.(awserr.Error).Code() != "InvalidLaunchTemplateName.AlreadyExistsException" {
 			return reconcile.Result{}, fmt.Errorf("creating launch template, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found launch template %s", aws.StringValue(discovery.Name(substrate)))
+		logging.FromContext(ctx).Debugf("Found launch template %s", aws.StringValue(discovery.Name(substrate)))
 	} else {
 		logging.FromContext(ctx).Infof("Created launch template %s", aws.StringValue(discovery.Name(substrate)))
 	}

--- a/substrate/pkg/controller/substrate/infrastructure/internetgateway.go
+++ b/substrate/pkg/controller/substrate/infrastructure/internetgateway.go
@@ -41,12 +41,12 @@ func (i *InternetGateway) Create(ctx context.Context, substrate *v1alpha1.Substr
 	}
 	if _, err := i.EC2.AttachInternetGatewayWithContext(ctx, &ec2.AttachInternetGatewayInput{InternetGatewayId: internetGateway.InternetGatewayId, VpcId: substrate.Status.Infrastructure.VPCID}); err != nil {
 		if err.(awserr.Error).Code() == "Resource.AlreadyAssociated" {
-			logging.FromContext(ctx).Infof("Found internet gateway attachment %s to %s", aws.StringValue(internetGateway.InternetGatewayId), aws.StringValue(substrate.Status.Infrastructure.VPCID))
+			logging.FromContext(ctx).Debugf("Found internet gateway attachment %s to %s", aws.StringValue(internetGateway.InternetGatewayId), aws.StringValue(substrate.Status.Infrastructure.VPCID))
 		} else {
 			return reconcile.Result{}, fmt.Errorf("attaching internet gateway, %w", err)
 		}
 	} else {
-		logging.FromContext(ctx).Infof("Created internet gateway attachment %s to %s", aws.StringValue(internetGateway.InternetGatewayId), aws.StringValue(substrate.Status.Infrastructure.VPCID))
+		logging.FromContext(ctx).Debugf("Created internet gateway attachment %s to %s", aws.StringValue(internetGateway.InternetGatewayId), aws.StringValue(substrate.Status.Infrastructure.VPCID))
 	}
 	if _, err := i.EC2.CreateRouteWithContext(ctx, &ec2.CreateRouteInput{
 		RouteTableId:         substrate.Status.Infrastructure.PublicRouteTableID,
@@ -55,7 +55,7 @@ func (i *InternetGateway) Create(ctx context.Context, substrate *v1alpha1.Substr
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("creating route for internet gateway, %w", err)
 	} else {
-		logging.FromContext(ctx).Infof("Ensured route for internet gateway %s", aws.StringValue(internetGateway.InternetGatewayId))
+		logging.FromContext(ctx).Debugf("Ensured route for internet gateway %s", aws.StringValue(internetGateway.InternetGatewayId))
 	}
 	return reconcile.Result{}, nil
 }
@@ -66,7 +66,7 @@ func (i *InternetGateway) ensure(ctx context.Context, substrate *v1alpha1.Substr
 		return nil, fmt.Errorf("describing internet gateways, %w", err)
 	}
 	if len(descrbeInternetGatewaysOutput.InternetGateways) > 0 {
-		logging.FromContext(ctx).Infof("Found internet gateway %s", substrate.Name)
+		logging.FromContext(ctx).Debugf("Found internet gateway %s", substrate.Name)
 		return descrbeInternetGatewaysOutput.InternetGateways[0], nil
 	}
 	createInternetGatewayOutput, err := i.EC2.CreateInternetGatewayWithContext(ctx, &ec2.CreateInternetGatewayInput{

--- a/substrate/pkg/controller/substrate/infrastructure/routetable.go
+++ b/substrate/pkg/controller/substrate/infrastructure/routetable.go
@@ -54,7 +54,7 @@ func (r *RouteTable) ensure(ctx context.Context, substrate *v1alpha1.Substrate, 
 		return nil, fmt.Errorf("describing route tables, %w", err)
 	}
 	if len(describeRouteTablesOutput.RouteTables) > 0 {
-		logging.FromContext(ctx).Infof("Found route table %s", aws.StringValue(name))
+		logging.FromContext(ctx).Debugf("Found route table %s", aws.StringValue(name))
 		return describeRouteTablesOutput.RouteTables[0], nil
 	}
 	createRouteTableOutput, err := r.EC2.CreateRouteTableWithContext(ctx, &ec2.CreateRouteTableInput{

--- a/substrate/pkg/controller/substrate/infrastructure/securitygroup.go
+++ b/substrate/pkg/controller/substrate/infrastructure/securitygroup.go
@@ -58,7 +58,7 @@ func (s *SecurityGroup) Create(ctx context.Context, substrate *v1alpha1.Substrat
 		if err.(awserr.Error).Code() != "InvalidPermission.Duplicate" {
 			return reconcile.Result{}, fmt.Errorf("authorizing security group ingress, %w", err)
 		}
-		logging.FromContext(ctx).Infof("Found ingress rules for security group %s", aws.StringValue(discovery.Name(substrate)))
+		logging.FromContext(ctx).Debugf("Found ingress rules for security group %s", aws.StringValue(discovery.Name(substrate)))
 	} else {
 		logging.FromContext(ctx).Infof("Created ingress rules for security group %s", aws.StringValue(discovery.Name(substrate)))
 	}
@@ -71,7 +71,7 @@ func (s *SecurityGroup) ensure(ctx context.Context, substrate *v1alpha1.Substrat
 		return nil, fmt.Errorf("describing security groups, %w", err)
 	}
 	if len(describeSecurityGroupsOutput.SecurityGroups) > 0 {
-		logging.FromContext(ctx).Infof("Found security group %s", aws.StringValue(discovery.Name(substrate)))
+		logging.FromContext(ctx).Debugf("Found security group %s", aws.StringValue(discovery.Name(substrate)))
 		return describeSecurityGroupsOutput.SecurityGroups[0], nil
 	}
 	createSecurityGroupOutput, err := s.EC2.CreateSecurityGroupWithContext(ctx, &ec2.CreateSecurityGroupInput{

--- a/substrate/pkg/controller/substrate/infrastructure/subnets.go
+++ b/substrate/pkg/controller/substrate/infrastructure/subnets.go
@@ -76,7 +76,7 @@ func (s *Subnets) ensure(ctx context.Context, substrate *v1alpha1.Substrate, sub
 			return nil, fmt.Errorf("associating route table with subnet, %w", err)
 		}
 	}
-	logging.FromContext(ctx).Infof("Ensured association of route table %s to subnet %s", aws.StringValue(routeTableID), aws.StringValue(subnet.SubnetId))
+	logging.FromContext(ctx).Debugf("Ensured association of route table %s to subnet %s", aws.StringValue(routeTableID), aws.StringValue(subnet.SubnetId))
 	if !subnetSpec.Public {
 		return subnet, nil
 	}
@@ -84,7 +84,7 @@ func (s *Subnets) ensure(ctx context.Context, substrate *v1alpha1.Substrate, sub
 		return nil, fmt.Errorf("modifying subnet attribute, %w", err)
 	}
 	subnet.MapPublicIpOnLaunch = aws.Bool(true)
-	logging.FromContext(ctx).Infof("Ensured subnet %s is public", aws.StringValue(subnet.SubnetId))
+	logging.FromContext(ctx).Debugf("Ensured subnet %s is public", aws.StringValue(subnet.SubnetId))
 	return subnet, nil
 }
 
@@ -95,7 +95,7 @@ func (s *Subnets) ensureSubnet(ctx context.Context, substrate *v1alpha1.Substrat
 		return nil, fmt.Errorf("describing subnets, %w", err)
 	}
 	if len(describeSubnetsOutput.Subnets) > 0 {
-		logging.FromContext(ctx).Infof("Found subnet %s", aws.StringValue(name))
+		logging.FromContext(ctx).Debugf("Found subnet %s", aws.StringValue(name))
 		return describeSubnetsOutput.Subnets[0], nil
 
 	}
@@ -130,7 +130,7 @@ func (s *Subnets) Delete(ctx context.Context, substrate *v1alpha1.Substrate) (re
 			if _, err := s.EC2.DisassociateRouteTableWithContext(ctx, &ec2.DisassociateRouteTableInput{AssociationId: association.RouteTableAssociationId}); err != nil {
 				return reconcile.Result{}, fmt.Errorf("disassociating route table from subnet, %s", err)
 			}
-			logging.FromContext(ctx).Infof("Deleted association of route table %s to subnet %s", aws.StringValue(routeTable.RouteTableId), aws.StringValue(association.SubnetId))
+			logging.FromContext(ctx).Debugf("Deleted association of route table %s to subnet %s", aws.StringValue(routeTable.RouteTableId), aws.StringValue(association.SubnetId))
 		}
 	}
 	subnetsOutput, err := s.EC2.DescribeSubnetsWithContext(ctx, &ec2.DescribeSubnetsInput{Filters: discovery.Filters(substrate)})


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Adds a debug flag for the cli
- Fix the cli binary name to be kitctl
- Convert some info logs to debug logs specifically once related to discovery

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
