### PR TITLE
Revert "Refactored chart implementation for readability"

### DIFF
--- a/substrate/demo/apply.sh
+++ b/substrate/demo/apply.sh
@@ -12,9 +12,9 @@ clusterctl init --infrastructure aws --kubeconfig bootstrap.kubeconfig
 # Create Cluster
 kubectl apply --kubeconfig bootstrap.kubeconfig -f ./substrate.yaml
 kubectl get cluster substrate -w --kubeconfig bootstrap.kubeconfig
-clusterctl get kubeconfig substrate --kubeconfig bootstrap.kubeconfig >substrate.kubeconfig
-kubectl apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml --kubeconfig substrate.kubeconfig
 
 # Pivot Cluster
+clusterctl get kubeconfig substrate --kubeconfig bootstrap.kubeconfig >substrate.kubeconfig
+kubectl apply -f https://docs.projectcalico.org/v3.21/manifests/calico.yaml --kubeconfig substrate.kubeconfig
 clusterctl init --infrastructure aws --kubeconfig substrate.kubeconfig
 clusterctl move --kubeconfig bootstrap.kubeconfig --to-kubeconfig substrate.kubeconfig

--- a/substrate/demo/delete.sh
+++ b/substrate/demo/delete.sh
@@ -2,5 +2,5 @@
 
 # Delete Cluster
 clusterctl move --kubeconfig ./substrate.kubeconfig --to-kubeconfig ./bootstrap.kubeconfig
-kubectl delete --kubeconfig bootstrap.kubeconfig -f ./substrate.yaml || true
+kubectl delete --kubeconfig bootstrap.kubeconfig -f ./substrate.yaml
 kind delete cluster --name bootstrap


### PR DESCRIPTION
Reverts awslabs/kubernetes-iteration-toolkit#141

Ran into this issue with this change- 
```
reconciling addons.HelmCharts, upgrading chart: template: aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml:1:14: executing "aws-ebs-csi-driver/templates/serviceaccount-csi-controller.yaml" at <.Values.controller.serviceAccount.create>: nil pointer evaluating interface {}.create
```
After reverting this change locally it works fine.
Needs to be debugged why helm is not accepting this.