### PR TITLE
Adds support for deploying prometheus stack on substrate node

### DIFF
--- a/operator/pkg/controllers/etcd/pod.go
+++ b/operator/pkg/controllers/etcd/pod.go
@@ -45,14 +45,14 @@ func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 			TopologyKey:       "topology.kubernetes.io/zone",
 			WhenUnsatisfiable: v1.DoNotSchedule,
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: labelsFor(controlPlane.ClusterName()),
+				MatchLabels: labels(),
 			},
 		}, {
 			MaxSkew:           int32(1),
 			TopologyKey:       "kubernetes.io/hostname",
 			WhenUnsatisfiable: v1.DoNotSchedule,
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: labelsFor(controlPlane.ClusterName()),
+				MatchLabels: labels(),
 			},
 		}},
 		Containers: []v1.Container{{
@@ -64,6 +64,9 @@ func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 			}, {
 				ContainerPort: 2380,
 				Name:          "etcd-peer",
+			}, {
+				ContainerPort: 2381,
+				Name:          "metrics",
 			}},
 			VolumeMounts: []v1.VolumeMount{{
 				Name:      "etcd-data",
@@ -89,7 +92,7 @@ func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 				"--advertise-client-urls=" + advertizeClusterURL(controlPlane),
 				"--initial-advertise-peer-urls=" + advertizePeerURL(controlPlane),
 				"--listen-client-urls=https://$(NODE_IP):2379,https://127.0.0.1:2379",
-				"--listen-metrics-urls=http://127.0.0.1:2381",
+				"--listen-metrics-urls=http://$(NODE_IP):2381,http://127.0.0.1:2381",
 				"--listen-peer-urls=https://$(NODE_IP):2380",
 				"--name=$(NODE_ID)",
 				"--peer-cert-file=/etc/kubernetes/pki/etcd/peer/peer.crt",
@@ -212,6 +215,6 @@ func caPeerName(controlPlane *v1alpha1.ControlPlane) string {
 }
 
 func nodeSelector(clusterName string) map[string]string {
-	return functional.UnionStringMaps(labelsFor(clusterName),
+	return functional.UnionStringMaps(labels(),
 		map[string]string{object.ControlPlaneLabelKey: clusterName, instanceTypeLabelKey: instanceTypeLabelDefaultValue})
 }

--- a/operator/pkg/controllers/etcd/pod.go
+++ b/operator/pkg/controllers/etcd/pod.go
@@ -45,14 +45,14 @@ func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 			TopologyKey:       "topology.kubernetes.io/zone",
 			WhenUnsatisfiable: v1.DoNotSchedule,
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: labels(),
+				MatchLabels: labels,
 			},
 		}, {
 			MaxSkew:           int32(1),
 			TopologyKey:       "kubernetes.io/hostname",
 			WhenUnsatisfiable: v1.DoNotSchedule,
 			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: labels(),
+				MatchLabels: labels,
 			},
 		}},
 		Containers: []v1.Container{{
@@ -215,6 +215,6 @@ func caPeerName(controlPlane *v1alpha1.ControlPlane) string {
 }
 
 func nodeSelector(clusterName string) map[string]string {
-	return functional.UnionStringMaps(labels(),
+	return functional.UnionStringMaps(labels,
 		map[string]string{object.ControlPlaneLabelKey: clusterName, instanceTypeLabelKey: instanceTypeLabelDefaultValue})
 }

--- a/operator/pkg/controllers/etcd/service.go
+++ b/operator/pkg/controllers/etcd/service.go
@@ -31,11 +31,11 @@ func (c *Controller) reconcileService(ctx context.Context, controlPlane *v1alpha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceNameFor(controlPlane.ClusterName()),
 			Namespace: controlPlane.Namespace,
-			Labels:    labelsFor(controlPlane.ClusterName()),
+			Labels:    labels(),
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP: v1.ClusterIPNone,
-			Selector:  labelsFor(controlPlane.ClusterName()),
+			Selector:  labels(),
 			Ports: []v1.ServicePort{{
 				Port:       2380,
 				Name:       serverPortNameFor(controlPlane.ClusterName()),
@@ -63,8 +63,6 @@ func ServiceNameFor(clusterName string) string {
 	return fmt.Sprintf("%s-etcd", clusterName)
 }
 
-func labelsFor(clusterName string) map[string]string {
-	return map[string]string{
-		object.AppNameLabelKey: ServiceNameFor(clusterName),
-	}
+func labels() map[string]string {
+	return map[string]string{object.AppNameLabelKey: "etcd"}
 }

--- a/operator/pkg/controllers/etcd/service.go
+++ b/operator/pkg/controllers/etcd/service.go
@@ -31,11 +31,11 @@ func (c *Controller) reconcileService(ctx context.Context, controlPlane *v1alpha
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ServiceNameFor(controlPlane.ClusterName()),
 			Namespace: controlPlane.Namespace,
-			Labels:    labels(),
+			Labels:    labels,
 		},
 		Spec: v1.ServiceSpec{
 			ClusterIP: v1.ClusterIPNone,
-			Selector:  labels(),
+			Selector:  labels,
 			Ports: []v1.ServicePort{{
 				Port:       2380,
 				Name:       serverPortNameFor(controlPlane.ClusterName()),
@@ -63,6 +63,4 @@ func ServiceNameFor(clusterName string) string {
 	return fmt.Sprintf("%s-etcd", clusterName)
 }
 
-func labels() map[string]string {
-	return map[string]string{object.AppNameLabelKey: "etcd"}
-}
+var labels = map[string]string{object.AppNameLabelKey: "etcd"}

--- a/operator/pkg/controllers/etcd/statefulset.go
+++ b/operator/pkg/controllers/etcd/statefulset.go
@@ -50,11 +50,11 @@ func (c *Controller) reconcileStatefulSet(ctx context.Context, controlPlane *v1a
 			Namespace: controlPlane.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Selector:             &metav1.LabelSelector{MatchLabels: labels()},
+			Selector:             &metav1.LabelSelector{MatchLabels: labels},
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			ServiceName:          ServiceNameFor(controlPlane.ClusterName()),
 			Replicas:             aws.Int32(int32(controlPlane.Spec.Etcd.Replicas)),
-			Template:             v1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels()}, Spec: podSpec},
+			Template:             v1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}, Spec: podSpec},
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "etcd-data"}, Spec: persistentVolumeClaimSpec}},
 		},
 	}))

--- a/operator/pkg/controllers/etcd/statefulset.go
+++ b/operator/pkg/controllers/etcd/statefulset.go
@@ -50,13 +50,11 @@ func (c *Controller) reconcileStatefulSet(ctx context.Context, controlPlane *v1a
 			Namespace: controlPlane.Namespace,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: labelsFor(controlPlane.ClusterName()),
-			},
+			Selector:             &metav1.LabelSelector{MatchLabels: labels()},
 			PodManagementPolicy:  appsv1.ParallelPodManagement,
 			ServiceName:          ServiceNameFor(controlPlane.ClusterName()),
 			Replicas:             aws.Int32(int32(controlPlane.Spec.Etcd.Replicas)),
-			Template:             v1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labelsFor(controlPlane.ClusterName())}, Spec: podSpec},
+			Template:             v1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels()}, Spec: podSpec},
 			VolumeClaimTemplates: []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "etcd-data"}, Spec: persistentVolumeClaimSpec}},
 		},
 	}))

--- a/operator/pkg/controllers/master/kubeapiserver.go
+++ b/operator/pkg/controllers/master/kubeapiserver.go
@@ -74,7 +74,7 @@ func APIServerDeploymentName(clusterName string) string {
 
 func APIServerLabels(clustername string) map[string]string {
 	return map[string]string{
-		object.AppNameLabelKey: APIServerDeploymentName(clustername),
+		object.AppNameLabelKey: "apiserver",
 	}
 }
 
@@ -112,6 +112,7 @@ func apiServerPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 						v1.ResourceCPU: resource.MustParse("1"),
 					},
 				},
+				Ports: []v1.ContainerPort{{ContainerPort: 8080, Name: "metrics"}},
 				Args: []string{
 					"--advertise-address=$(NODE_IP)",
 					"--allow-privileged=true",
@@ -123,7 +124,8 @@ func apiServerPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 					"--etcd-certfile=/etc/kubernetes/pki/etcd/apiserver-etcd-client.crt",
 					"--etcd-keyfile=/etc/kubernetes/pki/etcd/apiserver-etcd-client.key",
 					"--etcd-servers=https://" + etcd.SvcFQDN(controlPlane.ClusterName(), controlPlane.Namespace) + ":2379",
-					"--insecure-port=0",
+					"--insecure-port=8080",
+					"--insecure-bind-address=$(NODE_IP)",
 					"--kubelet-client-certificate=/etc/kubernetes/pki/kubelet/apiserver-kubelet-client.crt",
 					"--kubelet-client-key=/etc/kubernetes/pki/kubelet/apiserver-kubelet-client.key",
 					"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",

--- a/substrate/README.md
+++ b/substrate/README.md
@@ -39,6 +39,19 @@ spec:
 EOF
 ```
 
+### Accessing metrics from prometheus and grafana
+
+```bash
+kubectl port-forward svc/prometheus-operated -n monitoring 9090:9090&
+kubectl port-forward svc/kube-prometheus-stack-grafana -n monitoring 8080:80&
+```
+
+### Allowing API server to trust kubelet endpoints
+
+```bash
+kubectl certificate approve $(k get csr | grep "Pending" | awk '{print $1}')
+```
+
 ### cleanup
 
 - To remove the kubernetes cluster provisioned using kit-operator

--- a/substrate/pkg/controller/substrate/cluster/addons/awsloadbalancer.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/awsloadbalancer.go
@@ -52,7 +52,7 @@ func (l *AWSLoadBalancer) Create(ctx context.Context, substrate *v1alpha1.Substr
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("tagging resources, %w", err)
 	}
-	logging.FromContext(ctx).Debug("Tagged subnets with %s=%s", "kubernetes.io/role/elb", "1")
+	logging.FromContext(ctx).Debugf("Tagged subnets with %s=%s", "kubernetes.io/role/elb", "1")
 	return reconcile.Result{}, nil
 }
 

--- a/substrate/pkg/controller/substrate/cluster/addons/karpenter.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/karpenter.go
@@ -100,7 +100,7 @@ func (k *Karpenter) Create(ctx context.Context, substrate *v1alpha1.Substrate) (
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("tagging resources, %w", err)
 	}
-	logging.FromContext(ctx).Debug("Tagged subnets and security groups with %s=%s", "karpenter.sh/discovery", substrate.Name)
+	logging.FromContext(ctx).Debugf("Tagged subnets and security groups with %s=%s", "karpenter.sh/discovery", substrate.Name)
 	// Apply Provisioner
 	if err := client.ApplyYAML(ctx, []byte(fmt.Sprintf(provisioner, substrate.Name))); err != nil {
 		return reconcile.Result{}, fmt.Errorf("applying provisioner, %w", err)

--- a/substrate/pkg/controller/substrate/cluster/addons/prometheusstack.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/prometheusstack.go
@@ -1,0 +1,97 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+
+	"github.com/awslabs/kubernetes-iteration-toolkit/substrate/pkg/apis/v1alpha1"
+	"github.com/awslabs/kubernetes-iteration-toolkit/substrate/pkg/utils/helm"
+	"github.com/awslabs/kubernetes-iteration-toolkit/substrate/pkg/utils/kubectl"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type PrometheusStack struct{}
+
+func (p *PrometheusStack) Create(ctx context.Context, substrate *v1alpha1.Substrate) (reconcile.Result, error) {
+	if !substrate.Status.IsReady() {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if err := helm.NewClient(*substrate.Status.Cluster.KubeConfig).Apply(ctx, &helm.Chart{
+		Namespace:       "monitoring",
+		Name:            "kube-prometheus-stack",
+		Repository:      "https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-34.0.0/",
+		Version:         "34.0.0",
+		CreateNamespace: true,
+		Values: map[string]interface{}{
+			"coreDns":               map[string]interface{}{"enabled": false},
+			"kubeProxy":             map[string]interface{}{"enabled": false},
+			"kubeEtcd":              map[string]interface{}{"enabled": false},
+			"alertmanager":          map[string]interface{}{"enabled": false},
+			"kubeScheduler":         map[string]interface{}{"enabled": false},
+			"kubeApiServer":         map[string]interface{}{"enabled": false},
+			"kubeStateMetrics":      map[string]interface{}{"enabled": false},
+			"kubeControllerManager": map[string]interface{}{"enabled": false},
+			"prometheus":            map[string]interface{}{"serviceMonitor": map[string]interface{}{"selfMonitor": false}},
+			"prometheusOperator":    map[string]interface{}{"serviceMonitor": map[string]interface{}{"selfMonitor": false}},
+		},
+	}); err != nil {
+		return reconcile.Result{}, fmt.Errorf("applying chart, %w", err)
+	}
+	// configure podmonitors
+	client, err := kubectl.NewClient(*substrate.Status.Cluster.KubeConfig)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("initializing client, %w", err)
+	}
+	for _, name := range []string{"apiserver", "etcd"} {
+		var buf bytes.Buffer
+		tmpl := template.Must(template.New("Text").Parse(podMonitorTemplate))
+		err := tmpl.Execute(&buf, struct{ ComponentName string }{ComponentName: name})
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("error when executing template, %w", err)
+		}
+		if err := client.ApplyYAML(ctx, buf.Bytes()); err != nil {
+			return reconcile.Result{}, fmt.Errorf("applying pod monitors, %w", err)
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+func (p *PrometheusStack) Delete(_ context.Context, _ *v1alpha1.Substrate) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+
+var podMonitorTemplate = `
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .ComponentName }}-pods
+  namespace: monitoring
+  labels:
+    release: kube-prometheus-stack
+spec:
+  jobLabel: {{ .ComponentName }}-guest
+  namespaceSelector:
+    matchNames:
+    - default
+  selector:
+    matchLabels:
+      kit.k8s.sh/app: {{ .ComponentName }}
+  podMetricsEndpoints:
+  - port: metrics
+`

--- a/substrate/pkg/controller/substrate/cluster/config.go
+++ b/substrate/pkg/controller/substrate/cluster/config.go
@@ -212,7 +212,7 @@ After=docker.service iptables-restore.service
 Requires=docker.service
 
 [Service]
-ExecStart=/usr/bin/kubelet --hostname-override=%s --pod-manifest-path=/etc/kubernetes/manifests --kubeconfig=/etc/kubernetes/kubelet.conf  --cgroup-driver=systemd  --container-runtime=docker --network-plugin=cni --pod-infra-container-image=public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1 --node-labels=kit.aws/substrate=control-plane
+ExecStart=/usr/bin/kubelet --cluster-dns=10.96.0.10 --cluster-domain=cluster.local --hostname-override=%s --pod-manifest-path=/etc/kubernetes/manifests --kubeconfig=/etc/kubernetes/kubelet.conf  --cgroup-driver=systemd  --container-runtime=docker --network-plugin=cni --pod-infra-container-image=public.ecr.aws/eks-distro/kubernetes/pause:v1.18.9-eks-1-18-1 --node-labels=kit.aws/substrate=control-plane
 Restart=always`, substrate.Name)), 0644); err != nil {
 		return fmt.Errorf("writing kubelet configuration, %w", err)
 	}

--- a/substrate/pkg/controller/substrate/controller.go
+++ b/substrate/pkg/controller/substrate/controller.go
@@ -70,6 +70,7 @@ func NewController(ctx context.Context) *Controller {
 			&addons.KubeProxy{},
 			&addons.RBAC{},
 			&addons.Tekton{},
+			&addons.PrometheusStack{},
 		},
 	}
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- This change also includes creating pod monitors for monitoring guest cluster API servers and etcd. KCM, scheduler and other components will be added later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
