### PR TITLE
Add formula path to github action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,6 +83,7 @@ jobs:
       uses: mislav/bump-homebrew-formula-action@v1
       with:
         formula-name: kitctl
+        formula-path: kitctl.rb
         homebrew-tap: awslabs/kubernetes-iteration-toolkit
         base-branch: main
         download-url: https://github.com/awslabs/kubernetes-iteration-toolkit/releases/download/${{ env.RELEASE_VERSION }}/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip


### PR DESCRIPTION
Description of changes:
I thought `path` wasn't needed as I was passing the formulae name but the action defaults to `Formula/<formula-name>.rb`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
