### PR TITLE
[WIP] Reconcile authenticator as part of DP reconciler

### DIFF
--- a/operator/charts/kit-operator/crds/data-plane-crd.yaml
+++ b/operator/charts/kit-operator/crds/data-plane-crd.yaml
@@ -42,6 +42,8 @@ spec:
                 description: ClusterName is used to connect the worker nodes to a
                   control plane clusterName.
                 type: string
+              instanceProfile:
+                type: string
               instanceTypes:
                 description: InstanceTypes is an optional field thats lets user specify
                   the instance types for worker nodes, defaults to instance types

--- a/operator/hack/toolchain.sh
+++ b/operator/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     go install github.com/mitchellh/golicense@v0.2.0
     go install github.com/onsi/ginkgo/ginkgo@v1.16.5
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220113220429-45b13b951f77
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."

--- a/operator/pkg/apis/dataplane/v1alpha1/dataplane.go
+++ b/operator/pkg/apis/dataplane/v1alpha1/dataplane.go
@@ -52,7 +52,8 @@ type DataPlaneSpec struct {
 	// InstanceTypes is an optional field thats lets user specify the instance
 	// types for worker nodes, defaults to instance types "t2.xlarge", "t3.xlarge" or "t3a.xlarge"
 	// +optional
-	InstanceTypes []string `json:"instanceTypes,omitempty"`
+	InstanceTypes   []string `json:"instanceTypes,omitempty"`
+	InstanceProfile string   `json:"instanceProfile,omitempty"`
 	// AllocationStrategy helps user define the strategy to provision worker nodes in EC2,
 	// defaults to "lowest-price"
 	// +optional

--- a/operator/pkg/apis/dataplane/v1alpha1/dataplane.go
+++ b/operator/pkg/apis/dataplane/v1alpha1/dataplane.go
@@ -52,8 +52,11 @@ type DataPlaneSpec struct {
 	// InstanceTypes is an optional field thats lets user specify the instance
 	// types for worker nodes, defaults to instance types "t2.xlarge", "t3.xlarge" or "t3a.xlarge"
 	// +optional
-	InstanceTypes   []string `json:"instanceTypes,omitempty"`
-	InstanceProfile string   `json:"instanceProfile,omitempty"`
+	InstanceTypes []string `json:"instanceTypes,omitempty"`
+	// InstanceProfile is an optional field thats lets user specify a custom
+	// instance profile for the instances created
+	// +optional
+	InstanceProfile string `json:"instanceProfile,omitempty"`
 	// AllocationStrategy helps user define the strategy to provision worker nodes in EC2,
 	// defaults to "lowest-price"
 	// +optional

--- a/operator/pkg/awsprovider/iam/reconciler.go
+++ b/operator/pkg/awsprovider/iam/reconciler.go
@@ -182,7 +182,7 @@ func createInstanceProfile(ctx context.Context, iamAPI *awsprovider.IAM, profile
 }
 
 func KitNodeRoleNameFor(clusterName string) string {
-	return fmt.Sprintf("KitDPRole-%s", clusterName)
+	return fmt.Sprintf("KitDP-%s", clusterName)
 }
 
 func KitNodeInstanceProfileNameFor(clusterName string) string {

--- a/operator/pkg/awsprovider/launchtemplate/reconciler.go
+++ b/operator/pkg/awsprovider/launchtemplate/reconciler.go
@@ -124,7 +124,7 @@ func (c *Controller) createLaunchTemplate(ctx context.Context, dataplane *v1alph
 					VolumeType:          ptr.String("gp3"),
 				}},
 			},
-			InstanceType:       ptr.String("t2.xlarge"), // TODO get this from dataplane spec
+			InstanceType:       ptr.String("t2.xlarge"),
 			ImageId:            ptr.String(amiID),
 			IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{Name: aws.String(instanceProfile)},
 			Monitoring:         &ec2.LaunchTemplatesMonitoringRequest{Enabled: ptr.Bool(true)},

--- a/operator/pkg/components/iamauthenticator/iamauthenticator.go
+++ b/operator/pkg/components/iamauthenticator/iamauthenticator.go
@@ -30,7 +30,7 @@ import (
 
 func Config(ctx context.Context, name, ns, instanceRole, accountID string) (*v1.ConfigMap, error) {
 	configMapBytes, err := parseTemplate(config, struct{ Name, ClusterName, Namespace, KitNodeRole, AWSAccountID, PrivateDNS, SessionName string }{
-		Name:         AuthenticatorConfigMapName(name),
+		Name:         ConfigMapName(name),
 		ClusterName:  name,
 		Namespace:    ns,
 		KitNodeRole:  instanceRole,
@@ -148,7 +148,7 @@ func parseTemplate(strtmpl string, obj interface{}) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func AuthenticatorConfigMapName(clusterName string) string {
+func ConfigMapName(clusterName string) string {
 	return fmt.Sprintf("%s-auth-config", clusterName)
 }
 

--- a/operator/pkg/controllers/dataplane/authenticator.go
+++ b/operator/pkg/controllers/dataplane/authenticator.go
@@ -35,7 +35,7 @@ type Authenticator struct {
 	cloudProvider awsprovider.AccountMetadata
 }
 
-// Reconcile creates required configs for aws-iam-authenticator and stores them as secret in api server
+// Reconcile creates required configs for aws-iam-authenticator and stores them as secret in the host cluster
 func (a *Authenticator) Reconcile(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
 	accountID, err := a.cloudProvider.ID()
 	if err != nil {

--- a/operator/pkg/controllers/dataplane/authenticator.go
+++ b/operator/pkg/controllers/dataplane/authenticator.go
@@ -12,53 +12,69 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package master
+package dataplane
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/apis/controlplane/v1alpha1"
+	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/apis/dataplane/v1alpha1"
+	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/awsprovider"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/awsprovider/iam"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/components/iamauthenticator"
+	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/controllers/master"
+	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/kubeprovider"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/utils/object"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// reconcileAuthenticator creates required configs for aws-iam-authenticator and stores them as secret in api server
-func (c *Controller) reconcileAuthenticator(ctx context.Context, controlPlane *v1alpha1.ControlPlane) error {
-	accountID, err := c.cloudProvider.ID()
+type Authenticator struct {
+	kubeClient    *kubeprovider.Client
+	cloudProvider awsprovider.AccountMetadata
+}
+
+// Reconcile creates required configs for aws-iam-authenticator and stores them as secret in api server
+func (a *Authenticator) Reconcile(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
+	accountID, err := a.cloudProvider.ID()
 	if err != nil {
 		return fmt.Errorf("getting provider account ID, %w", err)
 	}
-	configMap, err := iamauthenticator.Config(ctx, controlPlane.ClusterName(), controlPlane.Namespace,
-		iam.KitNodeRoleNameFor(controlPlane.ClusterName()), accountID)
+	nodeRole := dataplane.Spec.InstanceProfile
+	if nodeRole == "" {
+		nodeRole = iam.KitNodeRoleNameFor(dataplane.Spec.ClusterName)
+	}
+	configMap, err := iamauthenticator.Config(ctx, dataplane.Spec.ClusterName, dataplane.Namespace, nodeRole, accountID)
 	if err != nil {
 		return fmt.Errorf("getting config for authenticator, %w", err)
 	}
-	if err := c.kubeClient.EnsurePatch(ctx, &v1.ConfigMap{}, object.WithOwner(controlPlane, configMap)); err != nil {
+	if err := a.kubeClient.EnsurePatch(ctx, &v1.ConfigMap{}, object.WithOwner(dataplane, configMap)); err != nil {
 		return fmt.Errorf("creating config map for authenticator, %w", err)
 	}
-	return c.ensureDaemonSet(ctx, controlPlane)
+	return a.ensureDaemonSet(ctx, dataplane)
 }
 
-func (c *Controller) ensureDaemonSet(ctx context.Context, controlPlane *v1alpha1.ControlPlane) error {
-	return c.kubeClient.EnsurePatch(ctx, &appsv1.DaemonSet{}, object.WithOwner(controlPlane, &appsv1.DaemonSet{
+func (a *Authenticator) Finalize(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
+	//TODO
+	return nil
+}
+
+func (a *Authenticator) ensureDaemonSet(ctx context.Context, dataplane *v1alpha1.DataPlane) error {
+	return a.kubeClient.EnsurePatch(ctx, &appsv1.DaemonSet{}, object.WithOwner(dataplane, &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-authenticator", controlPlane.ClusterName()),
-			Namespace: controlPlane.Namespace,
+			Name:      fmt.Sprintf("%s-authenticator", dataplane.Spec.ClusterName),
+			Namespace: dataplane.Namespace,
 			Labels:    iamauthenticator.Labels(),
 		},
 		Spec: appsv1.DaemonSetSpec{
 			UpdateStrategy: appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType},
 			Selector:       &metav1.LabelSelector{MatchLabels: iamauthenticator.Labels()},
 			Template: iamauthenticator.PodSpec(func(template v1.PodTemplateSpec) v1.PodTemplateSpec {
-				template.Spec.NodeSelector = APIServerLabels(controlPlane.ClusterName())
+				template.Spec.NodeSelector = master.APIServerLabels(dataplane.Spec.ClusterName)
 				template.Spec.Volumes = append(template.Spec.Volumes, v1.Volume{Name: "config",
 					VolumeSource: v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{
-						LocalObjectReference: v1.LocalObjectReference{Name: iamauthenticator.AuthenticatorConfigMapName(controlPlane.ClusterName())},
+						LocalObjectReference: v1.LocalObjectReference{Name: iamauthenticator.ConfigMapName(dataplane.Spec.ClusterName)},
 					}},
 				})
 				return template

--- a/operator/pkg/controllers/master/kubeapiserver.go
+++ b/operator/pkg/controllers/master/kubeapiserver.go
@@ -115,11 +115,12 @@ func (c *Controller) podSpecFor(ctx context.Context, controlPlane *v1alpha1.Cont
 
 func (c *Controller) authenticatorConfigExists(ctx context.Context, controlPlane *v1alpha1.ControlPlane) (bool, error) {
 	cm := &v1.ConfigMap{}
-	if err := c.kubeClient.Get(ctx, types.NamespacedName{
-		Namespace: controlPlane.Namespace, Name: iamauthenticator.ConfigMapName(controlPlane.ClusterName())}, cm); err != nil {
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Namespace: controlPlane.Namespace,
+		Name: iamauthenticator.ConfigMapName(controlPlane.ClusterName())}, cm); err != nil {
 		if errors.IsNotFound(err) {
 			return false, nil
 		}
+		return false, fmt.Errorf("getting authenticator config, %w", err)
 	}
 	return true, nil
 }

--- a/operator/pkg/controllers/master/master.go
+++ b/operator/pkg/controllers/master/master.go
@@ -58,7 +58,6 @@ func (c *Controller) Reconcile(ctx context.Context, controlPlane *v1alpha1.Contr
 		c.reconcileKCMCloudConfig,
 		c.reconcileKCM,
 		c.reconcileScheduler,
-		c.reconcileAuthenticator,
 		c.iamController.Reconcile,
 		c.reconcileEncryptionProviderConfig,
 		c.reconcileEncryptionProvider,


### PR DESCRIPTION
Issue #, if available:

Description of changes:

We need to provide instance-profile/role as part of Dataplane creation to have custom instance profile on nodes. However, in the existing functionality we add the role to authenticator as part of control plane reconciliation. This created an issue as the role added to authenticator differs from role provided in DP spec and node fails to authenticate. This PR makes sure authenticator config and daemonset is created/reconciled as part of the Dataplane object. If there is no Dataplane object created authenticator will not be deployed.

This above change created another issue as API server is configured to mount authenticator config files and if authenticator config doesn't exists when control plane is created API server is stuck in container creating. To get around this issue, now the API server reconciler by default creates API server pod spec without authenticator config and checks if authenticator config exists in the cluster. If authenticator config is found, API server is reconciled with config mounted to the API server.

One caveat with this approach- All Dataplane objects are required to have same instance profile/role as we don't have the functionality yet to append roles to authenticator config. Once we add this functionality we will be able to support instances with different roles in KIT dataplane.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
