### PR TITLE
Update makefile and add go version to actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.17.1'
       - uses: actions/cache@v2
         with:
           path: |
@@ -65,7 +68,7 @@ jobs:
     - name: Set env
       run: |
         echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.17.1'
     - name: Build the KIT CLI

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -70,9 +70,17 @@ docs:
 		-template-dir $(shell go env GOMODCACHE)/github.com/ahmetb/gen-crd-api-reference-docs@v0.3.0/template
 
 publish: ## Generate release manifests and publish a versioned container image.
-	yq e -i ".controller.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-operator ko publish --platform=linux/arm64,linux/amd64 --bare -t $(RELEASE_VERSION) ./cmd/controller)\"" charts/kit-operator/values.yaml
-	yq e -i ".webhook.image = \"$$(KO_DOCKER_REPO=public.ecr.aws/kit/kit-webhook ko publish --platform=linux/arm64,linux/amd64 --bare -t $(RELEASE_VERSION) ./cmd/webhook)\"" charts/kit-operator/values.yaml
-	yq e -i '.version = "$(subst v,,${RELEASE_VERSION})"' charts/kit-operator/Chart.yaml
+	$(eval CONTROLLER_IMAGE := $(shell KO_DOCKER_REPO=public.ecr.aws/kit/kit-operator ko publish --platform=linux/arm64,linux/amd64 --bare -t $(RELEASE_VERSION) ./cmd/controller))
+	@echo 'Controller image = '$(CONTROLLER_IMAGE)
+	@test -n "$(CONTROLLER_IMAGE)" || (echo 'Controller Image version not defined' && exit 1)
+	yq e -i ".controller.image = \""$(CONTROLLER_IMAGE)"\"" charts/kit-operator/values.yaml || { echo "failed"; exit 1; }
+
+	$(eval WEBHOOK_IMAGE := $(shell KO_DOCKER_REPO=public.ecr.aws/kit/kit-webhook ko publish --platform=linux/arm64,linux/amd64 --bare -t $(RELEASE_VERSION) ./cmd/webhook))
+	@echo 'Webhook image = '$(WEBHOOK_IMAGE)
+	@test -n "$(WEBHOOK_IMAGE)" || (echo 'Webhook Image version not defined' && exit 1)
+	yq e -i ".webhook.image = \""$(WEBHOOK_IMAGE)"\"" charts/kit-operator/values.yaml || { echo "failed"; exit 1; }
+
+	yq e -i '.version = "$(subst v,,${RELEASE_VERSION})"' charts/kit-operator/Chart.yaml || { echo "failed"; exit 1; }
 
 toolchain: ## Install developer toolchain
 	./hack/toolchain.sh


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Currently if the `ko publish` command fails in makefile action doesn't fail. This PR adds check in Makefile for error checks.
- Update go version in releasing the operator image.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
