### PR TITLE
Revert admissions plugin in guest API server

### DIFF
--- a/operator/pkg/controllers/master/kubeapiserver.go
+++ b/operator/pkg/controllers/master/kubeapiserver.go
@@ -116,7 +116,7 @@ func apiServerPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 					"--allow-privileged=true",
 					"--authorization-mode=Node,RBAC",
 					"--client-ca-file=/etc/kubernetes/pki/ca/ca.crt",
-					"--enable-admission-plugins=NodeRestriction,PodSecurityPolicy,ExtendedResourceToleration",
+					"--enable-admission-plugins=NodeRestriction",
 					"--enable-bootstrap-token-auth=true",
 					"--etcd-cafile=/etc/kubernetes/pki/etcd-ca/ca.crt",
 					"--etcd-certfile=/etc/kubernetes/pki/etcd/apiserver-etcd-client.crt",


### PR DESCRIPTION
Issue #, if available:

Description of changes:
After syncing the flags with EKS we ran into an issue with admission plugins.
Nodes are not getting ready as the kube-proxy, cni pods fail to get created. Reverting this change for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
