### PR TITLE
Support bigger VPC for KIT env

### DIFF
--- a/substrate/cmd/kitctl/bootstrap.go
+++ b/substrate/cmd/kitctl/bootstrap.go
@@ -51,18 +51,20 @@ func bootstrap(cmd *cobra.Command, args []string) {
 	start := time.Now()
 	name := parseName(ctx, args)
 	logging.FromContext(ctx).Infof("Bootstrapping %q", name)
+	vpcCidrs := []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16", "10.5.0.0/16"}
 	if err := substrate.NewController(ctx).Reconcile(ctx, &v1alpha1.Substrate{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
+
 		Spec: v1alpha1.SubstrateSpec{
-			VPC:          &v1alpha1.VPCSpec{CIDR: "10.0.0.0/16"},
-			InstanceType: aws.String("r6g.large"),
+			VPC:          &v1alpha1.VPCSpec{CIDR: vpcCidrs},
+			InstanceType: aws.String("r6g.8xlarge"),
 			Subnets: []*v1alpha1.SubnetSpec{
-				{Zone: "us-west-2a", CIDR: "10.0.1.0/24"},
-				{Zone: "us-west-2b", CIDR: "10.0.2.0/24"},
-				{Zone: "us-west-2c", CIDR: "10.0.3.0/24"},
-				{Zone: "us-west-2a", CIDR: "10.0.100.0/24", Public: true},
-				{Zone: "us-west-2b", CIDR: "10.0.101.0/24", Public: true},
-				{Zone: "us-west-2c", CIDR: "10.0.102.0/24", Public: true},
+				{Zone: "us-west-2a", CIDR: vpcCidrs[0]},
+				{Zone: "us-west-2b", CIDR: vpcCidrs[1]},
+				{Zone: "us-west-2c", CIDR: vpcCidrs[2]},
+				{Zone: "us-west-2a", CIDR: vpcCidrs[3], Public: true},
+				{Zone: "us-west-2b", CIDR: vpcCidrs[4], Public: true},
+				{Zone: "us-west-2c", CIDR: vpcCidrs[5], Public: true},
 			},
 		},
 	}); err != nil {

--- a/substrate/pkg/apis/v1alpha1/substrate.go
+++ b/substrate/pkg/apis/v1alpha1/substrate.go
@@ -41,8 +41,7 @@ type Substrate struct {
 }
 
 type VPCSpec struct {
-	// TODO accept a slice of CIDR for megaXL we need to create multiple CIDRs
-	CIDR string `json:"cidr,omitempty"`
+	CIDR []string `json:"cidr,omitempty"`
 }
 
 type SubnetSpec struct {


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/198 

Description of changes:
This PR creates a bigger VPC for KIT environment as a whole and helps solves problems mentioned in #198 

### Testing 
```
hakuna@3c22fbe1d295 kitctl % ./kitctl bootstrap vpc8
Bootstrapping "vpc8"
Created role vpc8
Created address name vpc8-apiserver, IP 52.40.116.7
Ensured policy vpc8 for vpc8
Created address name vpc8-natgw, IP 52.10.241.252
Created instance profile vpc8
Created vpc vpc-0876b5e662311936b
Added role vpc8 to instance profile vpc8
Created role vpc8-tenant-controlplane-node-role
Created s3 bucket vpc8
Ensured policy vpc8-tenant-controlplane-node-role for vpc8-tenant-controlplane-node-role
Created route table vpc8-public
Created security group sg-043cc10da428512cc
Created ingress rules for security group vpc8
Created route table vpc8-private
Created instance profile vpc8-tenant-controlplane-node-role
Created launch template vpc8
Added role vpc8-tenant-controlplane-node-role to instance profile vpc8-tenant-controlplane-node-role
Ensured launch template version 2 for vpc8
Created internet gateway vpc8
Created subnet vpc8-us-west-2a-public
Created subnet vpc8-us-west-2b-public
Created subnet vpc8-us-west-2c-public
Created subnet vpc8-us-west-2a-private
Created subnet vpc8-us-west-2c-private
Created subnet vpc8-us-west-2b-private
Created NAT gateway vpc8, ID nat-0b52f41bcdee5e38d
Created instance i-0e07558bca54bdca2
NAT gateway is available vpc8
To access cluster run -

        export KUBECONFIG=/tmp/vpc8/etc/kubernetes/admin.conf

Applied https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.33.2/release.yaml
Installed chart https://aws.github.io/eks-charts/aws-vpc-cni
Applied https://storage.googleapis.com/tekton-releases/triggers/previous/v0.19.0/release.yaml
Applied https://github.com/tektoncd/dashboard/releases/download/v0.24.1/tekton-dashboard-release.yaml
Installed chart https://aws.github.io/eks-charts/aws-load-balancer-controller
Installed chart https://awslabs.github.io/kubernetes-iteration-toolkit/kit-operator
Installed chart https://charts.karpenter.sh/karpenter
Installed chart https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.3/aws-ebs-csi-driver
Installed chart https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-34.0.0//kube-prometheus-stack
✅ Bootstrapped "vpc8" after 4m24.362330726s
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


