### PR TITLE
Some improvements to the operator and substrate

### DIFF
--- a/operator/docs/examples/etcd-with-mixed-instances.yaml
+++ b/operator/docs/examples/etcd-with-mixed-instances.yaml
@@ -3,8 +3,8 @@
 ## Create hollow pods to pre-provision mixed instances for etcd pods
 ```bash
 ZONES=("a" "b" "c")
-SIZES=("m5.large" "t3.large" "c5.2xlarge")
-CONTROL_PLANE=foo 
+SIZES=("t3.medium" "t3.medium" "t2.medium")
+CONTROL_PLANE=foo
 for i in {1..3}; do
 cat <<EOF | kubectl apply -f -
   apiVersion: v1
@@ -34,6 +34,59 @@ apiVersion: kit.k8s.sh/v1alpha1
 kind: ControlPlane
 metadata:
   name: ${CONTROL_PLANE} # Desired Cluster name
-  namespace: guest
+spec:
+  kubernetesVersion: "1.21"
+  master:
+    apiServer:
+      replicas: 2
+      spec:
+        containers:
+        - name: apiserver
+          args:
+            - --max-requests-inflight=400
+            - --max-mutating-requests-inflight=200
+    controllerManager:
+      spec:
+        containers:
+        - name: controller-manager
+          args:
+            - --controllers=*
+            - --kube-api-qps=300
+            - --kube-api-burst=400
+    scheduler:
+      spec:
+        containers:
+        - name: scheduler
+          args:
+            - --kube-api-qps=300
+            - --kube-api-burst=400
+  etcd:
+    spec:
+      containers:
+      - name: etcd
+        resources:
+          requests:
+            memory: 2Gi
+EOF
+```
+
+# Create Dataplane nodes for the guest cluster provisioned
+```bash
+CONTROL_PLANE=foo
+cat <<EOF | kubectl apply -f -
+apiVersion: kit.k8s.sh/v1alpha1
+kind: DataPlane
+metadata:
+  name: ${CONTROL_PLANE}-nodes
+spec:
+  clusterName: ${CONTROL_PLANE} # Desired Cluster Name
+  nodeCount: 10
+  subnetSelector:
+    kit.aws/substrate: ${MANAGEMENT_CLUSTER_NAME}
+  instanceTypes:
+    - c4.xlarge
+    - c5.xlarge
+    - c4.4xlarge
+    - c5.4xlarge
 EOF
 ```

--- a/operator/pkg/controllers/master/certificates.go
+++ b/operator/pkg/controllers/master/certificates.go
@@ -79,7 +79,9 @@ func kubeAPIServerCertConfig(hostname string, nn types.NamespacedName) *secrets.
 			CommonName: "kube-apiserver",
 			AltNames: certutil.AltNames{
 				DNSNames: []string{hostname, "localhost", "kubernetes", "kubernetes.default",
-					"kubernetes.default.svc", "kubernetes.default.svc.cluster.local"},
+					"kubernetes.default.svc", "kubernetes.default.svc.cluster.local",
+					fmt.Sprintf("%s-cp.%s.svc.cluster.local", nn.Name, nn.Namespace),
+				},
 				IPs: []net.IP{net.IPv4(127, 0, 0, 1), apiServerVirtualIP()},
 			},
 		},

--- a/operator/pkg/utils/imageprovider/imageprovider.go
+++ b/operator/pkg/utils/imageprovider/imageprovider.go
@@ -19,6 +19,7 @@ var (
 		"1.19": kubeVersion119Tag,
 		"1.20": kubeVersion120Tag,
 		"1.21": kubeVersion121Tag,
+		"1.22": kubeVersion122Tag,
 	}
 )
 
@@ -31,6 +32,7 @@ const (
 	kubeVersion119Tag = "v1.19.13-eks-1-19-9"
 	kubeVersion120Tag = "v1.20.7-eks-1-20-6"
 	kubeVersion121Tag = "v1.21.2-eks-1-21-4"
+	kubeVersion122Tag = "v1.22.6-eks-1-22-5"
 	repositoryName    = "public.ecr.aws/eks-distro/"
 	busyBoxImage      = "public.ecr.aws/docker/library/busybox:stable"
 )

--- a/substrate/cmd/kitctl/root.go
+++ b/substrate/cmd/kitctl/root.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -36,6 +38,7 @@ func main() {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	rand.Seed(time.Now().UnixNano())
 	logger := zap.New(zapcore.NewCore(zapcore.NewConsoleEncoder(zapcore.EncoderConfig{MessageKey: "message"}),
 		customLogWriteTo(ctx, os.Stdout), zap.LevelEnablerFunc(func(level zapcore.Level) bool {
 			return level >= logLevel

--- a/substrate/pkg/controller/substrate/cluster/addons/awsvpccni.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/awsvpccni.go
@@ -33,7 +33,7 @@ func (a *AWSVPCCNI) Create(ctx context.Context, substrate *v1alpha1.Substrate) (
 		Namespace:  "kube-system",
 		Name:       "aws-vpc-cni",
 		Repository: "https://aws.github.io/eks-charts",
-		Version:    "1.1.13",
+		Version:    "1.1.16",
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("applying chart, %w", err)
 	}

--- a/substrate/pkg/controller/substrate/cluster/addons/karpenter.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/karpenter.go
@@ -66,7 +66,7 @@ func (k *Karpenter) Create(ctx context.Context, substrate *v1alpha1.Substrate) (
 		Namespace:       "karpenter",
 		Name:            "karpenter",
 		Repository:      "https://charts.karpenter.sh",
-		Version:         "0.7.3",
+		Version:         "0.9.0",
 		CreateNamespace: true,
 		Values: map[string]interface{}{
 			"clusterName":     substrate.Name,
@@ -90,13 +90,11 @@ func (k *Karpenter) Create(ctx context.Context, substrate *v1alpha1.Substrate) (
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("initializing client, %w", err)
 	}
+	subnets := append(substrate.Status.Infrastructure.PublicSubnetIDs, substrate.Status.Infrastructure.PrivateSubnetIDs...)
 	// Tag EC2 Resources
 	if _, err := k.EC2.CreateTagsWithContext(ctx, &ec2.CreateTagsInput{
-		Resources: aws.StringSlice(append(
-			substrate.Status.Infrastructure.PublicSubnetIDs,
-			aws.StringValue(substrate.Status.Infrastructure.SecurityGroupID),
-		)),
-		Tags: []*ec2.Tag{{Key: aws.String("karpenter.sh/discovery"), Value: aws.String(substrate.Name)}},
+		Resources: aws.StringSlice(append(subnets, aws.StringValue(substrate.Status.Infrastructure.SecurityGroupID))),
+		Tags:      []*ec2.Tag{{Key: aws.String("karpenter.sh/discovery"), Value: aws.String(substrate.Name)}},
 	}); err != nil {
 		return reconcile.Result{}, fmt.Errorf("tagging resources, %w", err)
 	}

--- a/substrate/pkg/controller/substrate/cluster/addons/tekton.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/tekton.go
@@ -37,7 +37,7 @@ rules:
   resources: ["controlplanes", "dataplanes"]
   verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
 - apiGroups: [""]
-  resources: ["serviceaccounts", "secrets", "namespaces", "nodes"]
+  resources: ["serviceaccounts", "secrets", "namespaces", "nodes", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]

--- a/substrate/pkg/controller/substrate/cluster/launchtemplate.go
+++ b/substrate/pkg/controller/substrate/cluster/launchtemplate.go
@@ -98,7 +98,7 @@ while [ true ]; do
     echo "\$(date) Syncing S3 files for \$dir"
     mkdir -p \$dir
     existing_checksum=\$(ls -alR \$dir | md5sum)
-    aws s3 sync s3://%[2]s/tmp/%[2]s\$dir "\$dir"
+    aws s3 sync s3://%[2]s\$dir "\$dir"
     new_checksum=\$(ls -alR \$dir | md5sum)
     if [ "\$new_checksum" != "\$existing_checksum" ]; then
 		echo "Successfully synced from S3 \$dir"

--- a/substrate/pkg/controller/substrate/controller.go
+++ b/substrate/pkg/controller/substrate/controller.go
@@ -107,7 +107,7 @@ func (c *Controller) Reconcile(ctx context.Context, substrate *v1alpha1.Substrat
 				if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "RequestLimitExceeded" {
 					logging.FromContext(ctx).Debugf("RequestLimitExceeded while reconciling %s, err %w", reflect.ValueOf(resource).Elem().Type(), err)
 				} else {
-					logging.FromContext(ctx).Errorf("reconciling %s, err %w", reflect.ValueOf(resource).Elem().Type(), err)
+					logging.FromContext(ctx).Errorf("reconciling %s, err %v", reflect.ValueOf(resource).Elem().Type(), err)
 					errs[i] = fmt.Errorf("reconciling %s, %w", reflect.ValueOf(resource).Elem().Type(), err)
 					cancel()
 					return

--- a/substrate/pkg/controller/substrate/controller.go
+++ b/substrate/pkg/controller/substrate/controller.go
@@ -17,11 +17,13 @@ package substrate
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"reflect"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -39,6 +41,7 @@ import (
 	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/util/workqueue"
+	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -101,9 +104,14 @@ func (c *Controller) Reconcile(ctx context.Context, substrate *v1alpha1.Substrat
 			}
 			result, err := f(ctx, mutable)
 			if err != nil {
-				errs[i] = fmt.Errorf("reconciling %s, %w", reflect.ValueOf(resource).Elem().Type(), err)
-				cancel()
-				return
+				if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "RequestLimitExceeded" {
+					logging.FromContext(ctx).Debugf("RequestLimitExceeded while reconciling %s, err %w", reflect.ValueOf(resource).Elem().Type(), err)
+				} else {
+					logging.FromContext(ctx).Errorf("reconciling %s, err %w", reflect.ValueOf(resource).Elem().Type(), err)
+					errs[i] = fmt.Errorf("reconciling %s, %w", reflect.ValueOf(resource).Elem().Type(), err)
+					cancel()
+					return
+				}
 			}
 			c.Lock()
 			runtime.Must(mergo.Merge(substrate, mutable))
@@ -111,7 +119,7 @@ func (c *Controller) Reconcile(ctx context.Context, substrate *v1alpha1.Substrat
 			if !result.Requeue && result.RequeueAfter == 0 {
 				return
 			}
-			time.Sleep(result.RequeueAfter + time.Second*1)
+			time.Sleep(result.RequeueAfter + time.Duration(rand.Intn(3000))*time.Millisecond)
 		}
 	})
 	return multierr.Combine(errs...)

--- a/tests/images/clusterloader2/Dockerfile
+++ b/tests/images/clusterloader2/Dockerfile
@@ -2,9 +2,9 @@ FROM golang:1.16.4 AS builder
 WORKDIR /go/src/k8s.io
 RUN git clone https://github.com/kubernetes/perf-tests
 WORKDIR /go/src/k8s.io/perf-tests/clusterloader2
-RUN GOPROXY=direct go build -o ./clusterloader ./cmd
+RUN GOPROXY=direct GOOS=linux CGO_ENABLED=0  go build -o ./clusterloader ./cmd
 
-FROM amazon/aws-cli
+FROM alpine:3.15.4
 WORKDIR /
-COPY --from=builder /go/src/k8s.io/perf-tests/clusterloader2/clusterloader .
-ENTRYPOINT ["bash"]
+COPY --from=builder /go/src/k8s.io/perf-tests/clusterloader2/clusterloader /clusterloader
+ENTRYPOINT ["/clusterloader"]


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Update example steps for running etcd on mixed instances
- Update AltNames to include control plane service name in the certificate
- Add support for running kubernetes version 1.22 in kit operator
- Update CNI and Karpenter version installed in KIT env
- Update the local path for writing config from /tmp to $HOME/.kit/env
- Update Dockerfile for cl2 
- Improve error logging when reconciler fails

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
