### PR TITLE
Use Github token for PR created for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,4 +94,4 @@ jobs:
           Update kitctl to ${{ env.RELEASE_VERSION }}
           Created by Github actions during Release CLI action
       env:
-        COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
+        COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Not able to test this in my Fork as the permissions for GITHUB_TOKEN are read only in a forker repo. So we will have to test this in this repo once we cut a release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
