### PR TITLE
add logging to kitenv

### DIFF
--- a/substrate/pkg/controller/substrate/cluster/addons/fluentbitcw.go
+++ b/substrate/pkg/controller/substrate/cluster/addons/fluentbitcw.go
@@ -1,0 +1,355 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/awslabs/kubernetes-iteration-toolkit/substrate/pkg/apis/v1alpha1"
+	"github.com/awslabs/kubernetes-iteration-toolkit/substrate/pkg/utils/kubectl"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var fluentbitNS = `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: amazon-cloudwatch
+  labels:
+    name: amazon-cloudwatch
+`
+
+var fluentbitCM = `
+apiVersion: v1
+data:
+  cluster.name:  %s
+  http.port: ""
+  http.server: "Off"
+  logs.region: %s
+  read.head: "On"
+  read.tail: "On"
+kind: ConfigMap
+metadata:
+  name: fluent-bit-cluster-info
+  namespace: amazon-cloudwatch
+`
+
+var fluentbitConfig = `
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fluent-bit-role
+rules:
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - pods
+      - pods/logs
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fluent-bit-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: fluent-bit-role
+subjects:
+  - kind: ServiceAccount
+    name: fluent-bit
+    namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                     5
+        Log_Level                 info
+        Daemon                    off
+        Parsers_File              parsers.conf
+        HTTP_Server               ${HTTP_SERVER}
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 ${HTTP_PORT}
+        storage.path              /var/fluent-bit/state/flb-storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.backlog.mem_limit 5M
+        
+    @INCLUDE application-log.conf
+  
+  application-log.conf: |
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*
+        Path                /var/log/containers/*.log
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  container_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_container.db
+        Mem_Buf_Limit       50MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Rotate_Wait         30
+        storage.type        filesystem
+        Read_from_Head      ${READ_FROM_HEAD}
+        Path_Key            path
+ 
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/fluent-bit*
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_log.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+        Path_Key            path
+ 
+    [INPUT]
+        Name                tail
+        Tag                 application.*
+        Path                /var/log/containers/cloudwatch-agent*
+        Docker_Mode         On
+        Docker_Mode_Flush   5
+        Docker_Mode_Parser  cwagent_firstline
+        Parser              docker
+        DB                  /var/fluent-bit/state/flb_cwagent.db
+        Mem_Buf_Limit       5MB
+        Skip_Long_Lines     On
+        Refresh_Interval    10
+        Read_from_Head      ${READ_FROM_HEAD}
+        Path_Key            path
+ 
+    [FILTER]
+        Name                kubernetes
+        Match               application.*
+        Kube_URL            https://kubernetes.default.svc:443
+        Kube_Tag_Prefix     application.var.log.containers.
+        Merge_Log           On
+        Merge_Log_Key       log_processed
+        K8S-Logging.Parser  On
+        K8S-Logging.Exclude Off
+        Labels              Off
+        Annotations         Off
+ 
+    [OUTPUT]
+        Name                cloudwatch
+        Match               application.*
+        region              ${AWS_REGION}
+        log_group_name      /${CLUSTER_NAME}
+        log_stream_name     $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        auto_create_group   true
+        extra_user_agent    container-insights
+        log_retention_days  30
+ 
+  parsers.conf: |
+    [PARSER]
+        Name                docker
+        Format              json
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+ 
+    [PARSER]
+        Name                syslog
+        Format              regex
+        Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+        Time_Key            time
+        Time_Format         %b %d %H:%M:%S
+ 
+    [PARSER]
+        Name                container_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+ 
+    [PARSER]
+        Name                cwagent_firstline
+        Format              regex
+        Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  template:
+    metadata:
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: fluent-bit
+        image: amazon/aws-for-fluent-bit:2.10.0
+        imagePullPolicy: Always
+        env:
+            - name: AWS_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: logs.region
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: cluster.name
+            - name: HTTP_SERVER
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.server
+            - name: HTTP_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: http.port
+            - name: READ_FROM_HEAD
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.head
+            - name: READ_FROM_TAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: fluent-bit-cluster-info
+                  key: read.tail
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CI_VERSION
+              value: "k8s/1.3.9"
+        resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 500m
+              memory: 100Mi
+        volumeMounts:
+        # Please don't change below read-only permissions
+        - name: fluentbitstate
+          mountPath: /var/fluent-bit/state
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc/
+        - name: runlogjournal
+          mountPath: /run/log/journal
+          readOnly: true
+        - name: dmesg
+          mountPath: /var/log/dmesg
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: fluentbitstate
+        hostPath:
+          path: /var/fluent-bit/state
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluent-bit-config
+        configMap:
+          name: fluent-bit-config
+      - name: runlogjournal
+        hostPath:
+          path: /run/log/journal
+      - name: dmesg
+        hostPath:
+          path: /var/log/dmesg
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
+`
+
+type FluentBit struct {
+	Region *string
+}
+
+func (t *FluentBit) Create(ctx context.Context, substrate *v1alpha1.Substrate) (reconcile.Result, error) {
+
+	if !substrate.Status.IsReady() {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	client, err := kubectl.NewClient(*substrate.Status.Cluster.KubeConfig)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("initializing client, %w", err)
+	}
+
+  	// Apply fluentbit ns
+	  if err := client.ApplyYAML(ctx, []byte(fluentbitNS)); err != nil {
+		return reconcile.Result{}, fmt.Errorf("applying fluentbit ns, %w", err)
+	}
+
+  	// Apply fluentbit configmp
+	if err := client.ApplyYAML(ctx, []byte(fmt.Sprintf(fluentbitCM, substrate.Name, *t.Region))); err != nil {
+		return reconcile.Result{}, fmt.Errorf("applying fluentbit cm, %w", err)
+	}
+
+	// Apply fluentbit daemonset
+	if err := client.ApplyYAML(ctx, []byte(fluentbitConfig)); err != nil {
+		return reconcile.Result{}, fmt.Errorf("applying fluentbit deamonset, %w", err)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (t *FluentBit) Delete(_ context.Context, _ *v1alpha1.Substrate) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}

--- a/substrate/pkg/controller/substrate/cluster/instanceprofile.go
+++ b/substrate/pkg/controller/substrate/cluster/instanceprofile.go
@@ -280,7 +280,9 @@ func desiredRolesFor(substrate *v1alpha1.Substrate) []role {
 						"autoscaling:DeleteAutoScalingGroup",
 						"autoscaling:UpdateAutoScalingGroup",
 						"autoscaling:SetDesiredCapacity",
-						"autoscaling:DescribeAutoScalingGroups"
+						"autoscaling:DescribeAutoScalingGroups",
+						"logs:*",
+						"cloudwatch:*"
 					],
 					"Resource": ["*"]
 				}
@@ -306,8 +308,10 @@ func desiredRolesFor(substrate *v1alpha1.Substrate) []role {
 						"iam:ListAttachedRolePolicies",
 						"kms:Encrypt",
 						"kms:Decrypt",
+						"logs:*",
 						"eks:*",
-						"s3:*"
+						"s3:*",
+						"cloudwatch:*"
 					],
 					"Resource": ["*"]
 				}

--- a/substrate/pkg/controller/substrate/controller.go
+++ b/substrate/pkg/controller/substrate/controller.go
@@ -75,6 +75,7 @@ func NewController(ctx context.Context) *Controller {
 			&addons.RBAC{},
 			&addons.Tekton{},
 			&addons.PrometheusStack{},
+			&addons.FluentBit{Region: session.Config.Region},
 		},
 	}
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add logging to KIT env using container native logging approach.
This approach support host level, container level logging for KIT Env as well KIT Guest clusters 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Testing 

```
hakuna@3c22fbe1d295 kitctl % ./kitctl bootstrap fluentbit-abcd
Bootstrapping "fluentbit-abcd"
Ensured policy fluentbit-abcd for fluentbit-abcd
Found vpc vpc-00d1976192b383618
Ensured policy fluentbit-abcd-tenant-controlplane-node-role for fluentbit-abcd-tenant-controlplane-node-role
Ensured launch template version 2 for fluentbit-abcd
Found instance i-069661d910cb575ae
To access cluster run -

        export KUBECONFIG=/tmp/fluentbit-abcd/etc/kubernetes/admin.conf

Applied https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
Applied https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/master/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
Applied https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.33.2/release.yaml
Upgraded chart https://aws.github.io/eks-charts/aws-vpc-cni
Applied https://storage.googleapis.com/tekton-releases/triggers/previous/v0.19.0/release.yaml
Applied https://github.com/tektoncd/dashboard/releases/download/v0.24.1/tekton-dashboard-release.yaml
Upgraded chart https://charts.karpenter.sh/karpenter
Upgraded chart https://aws.github.io/eks-charts/aws-load-balancer-controller
Upgraded chart https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/download/helm-chart-aws-ebs-csi-driver-2.6.3/aws-ebs-csi-driver
Upgraded chart https://awslabs.github.io/kubernetes-iteration-toolkit/kit-operator
Upgraded chart https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-34.0.0//kube-prometheus-stack
✅ Bootstrapped "fluentbit-abcd" after 3m38.146292567s

```


Logs in cloudwatch sample for an etcd pod of Guest cluster

```
{
    "log": "{\"level\":\"info\",\"ts\":\"2022-05-18T13:03:10.294Z\",\"caller\":\"mvcc/kvstore_compaction.go:56\",\"msg\":\"finished scheduled compaction\",\"compact-revision\":727,\"took\":\"1.319214ms\"}\n",
    "stream": "stderr",
    "log_processed": {
        "level": "info",
        "ts": "2022-05-18T13:03:10.294Z",
        "caller": "mvcc/kvstore_compaction.go:56",
        "msg": "finished scheduled compaction",
        "compact-revision": 727,
        "took": "1.319214ms"
    },
    "kubernetes": {
        "pod_name": "example-etcd-0",
        "namespace_name": "default",
        "pod_id": "ce993b2b-058e-4a27-8844-ffae18e663e5",
        "host": "ip-10-4-215-29.us-west-2.compute.internal",
        "container_name": "etcd",
        "docker_id": "610f98f796da02be9e48f277b862a4828f6da07deccdc242121261c7a41719cd",
        "container_hash": "public.ecr.aws/eks-distro/etcd-io/etcd@sha256:a60c9e8701e0ef4e1fdbd00328297ebe6ae20ed619eed7e50a072e3265193ce7",
        "container_image": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.16-eks-1-21-4"
    }



```



Log group name | Log source
-- | --
/aws/containerinsights/Cluster_Name/application | All log files in /var/log/containers
/aws/containerinsights/Cluster_Name/host | Logs from /var/log/dmesg, /var/log/secure, and /var/log/messages
/aws/containerinsights/Cluster_Name/dataplane | The logs in /var/log/journal for kubelet.service, kubeproxy.service, and docker.service.




