### PR TITLE
Fix S3 creation in us-east-1

### DIFF
--- a/substrate/cmd/kitctl/bootstrap.go
+++ b/substrate/cmd/kitctl/bootstrap.go
@@ -51,7 +51,7 @@ func bootstrap(cmd *cobra.Command, args []string) {
 	start := time.Now()
 	name := parseName(ctx, args)
 	logging.FromContext(ctx).Infof("Bootstrapping %q", name)
-	vpcCidrs := []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16", "10.5.0.0/16"}
+	vpcCidrs := []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16"}
 	if err := substrate.NewController(ctx).Reconcile(ctx, &v1alpha1.Substrate{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 
@@ -64,7 +64,6 @@ func bootstrap(cmd *cobra.Command, args []string) {
 				{Zone: "us-west-2c", CIDR: vpcCidrs[2]},
 				{Zone: "us-west-2a", CIDR: vpcCidrs[3], Public: true},
 				{Zone: "us-west-2b", CIDR: vpcCidrs[4], Public: true},
-				{Zone: "us-west-2c", CIDR: vpcCidrs[5], Public: true},
 			},
 		},
 	}); err != nil {

--- a/substrate/pkg/controller/substrate/cluster/config.go
+++ b/substrate/pkg/controller/substrate/cluster/config.go
@@ -199,9 +199,7 @@ func (c *Config) generateStaticPodManifests(cfg *kubeadm.InitConfiguration, subs
 }
 
 func (c *Config) ensureBucket(ctx context.Context, substrate *v1alpha1.Substrate) error {
-	if _, err := c.S3.CreateBucket(&s3.CreateBucketInput{Bucket: discovery.Name(substrate),
-		CreateBucketConfiguration: &s3.CreateBucketConfiguration{LocationConstraint: c.S3.Config.Region},
-	}); err != nil {
+	if _, err := c.S3.CreateBucket(&s3.CreateBucketInput{Bucket: discovery.Name(substrate)}); err != nil {
 		if err.(awserr.Error).Code() != s3.ErrCodeBucketAlreadyOwnedByYou {
 			return fmt.Errorf("creating S3 bucket, %w", err)
 		}


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/218

Description of changes:
- Some regions like `us-east-1` limit default CIDR count to 5, so we need to keep the defaults
- S3 bucket creation fix in `us-east-1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
