### PR TITLE
Revert "Use Github token for PR created for release"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,4 +94,4 @@ jobs:
           Update kitctl to ${{ env.RELEASE_VERSION }}
           Created by Github actions during Release CLI action
       env:
-        COMMITTER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts awslabs/kubernetes-iteration-toolkit#215

`GITHUB_TOKEN` fails to create the PR from Github actions