### PR TITLE
delete nodegroups as part of cluster deletion; abort cluster creation if cluster already exist…

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load.yaml
@@ -68,6 +68,16 @@ spec:
       workspace: config
     - name: results
       workspace: results
+  finally:    
+  - name: teardown
+    params:   
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
+    taskRef:
+      kind: Task
+      name:  awscli-eks-cluster-teardown
   workspaces:
   - name: config
   - name: source

--- a/tests/tasks/teardown/awscli-eks.yaml
+++ b/tests/tasks/teardown/awscli-eks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   description: |
     Teardown an EKS cluster.
-    This Task can be used to teardown an EKS cluster in an AWS account.
+    This Task can be used to teardown an EKS cluster with mng in an AWS account.
   params:
   - name: cluster-name
     description: The name of the EKS cluster which will be teared down.
@@ -26,4 +26,10 @@ spec:
       if [ -n "$(params.endpoint)" ]; then
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
       fi
+
+      for i in `aws eks list-nodegroups --cluster-name $(params.cluster-name) $ENDPOINT_FLAG | jq -r '.nodegroups[]'`;
+      do
+          aws eks delete-nodegroup --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG;
+          aws eks wait nodegroup-deleted --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG;
+      done;
       aws eks delete-cluster --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG


### PR DESCRIPTION
This PR adds the ability to:
-  delete all nodegroups at the time of deletion of cluster tekton task. 
- Adds `delete cluster` as a tekton `finally` step to pipeline which will help `tear` down cluster irrespective of the success/failure of previous steps in pipeline

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
