### PR TITLE
Increase sleep time to finish VAS scale up fully

### DIFF
--- a/tests/tasks/setup/eks/awscli-mng.yaml
+++ b/tests/tasks/setup/eks/awscli-mng.yaml
@@ -38,7 +38,7 @@ spec:
       if [ $(params.desired-nodes) -lt 5001  ] && [ $(params.desired-nodes) -gt 500 ]
       then
         echo "sleeping for 3hrs to workaround VAS cool off time"
-        sleep 10800
+        sleep 12000
       fi
 
       if [ -n "$(params.endpoint)" ]; then

--- a/tests/tasks/teardown/awscli-eks.yaml
+++ b/tests/tasks/teardown/awscli-eks.yaml
@@ -27,9 +27,9 @@ spec:
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
       fi
 
-      for i in `aws eks list-nodegroups --cluster-name $(params.cluster-name) $ENDPOINT_FLAG | jq -r '.nodegroups[]'`;
+      for i in `aws eks list-nodegroups --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region)  | jq -r '.nodegroups[]'`;
       do
-          aws eks delete-nodegroup --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG;
-          aws eks wait nodegroup-deleted --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG;
+          aws eks delete-nodegroup --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region);
+          aws eks wait nodegroup-deleted --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region);
       done;
       aws eks delete-cluster --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Increase sleep time further to finish VAS scale up fully before user tests kicks in. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
