### PR TITLE
add cwagent addon permanently to eks loadtests

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -1,0 +1,112 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: awscli-eks-cl2loadtest-with-addons
+  namespace: tekton-pipelines
+spec:
+  params:
+  - name: cluster-name
+  - name: endpoint
+  - name: servicerole
+  - name: desired-nodes
+  - name: host-cluster-node-role-arn
+  - name: pods-per-node
+  - name: nodes-per-namespace
+  - name: cl2-load-test-throughput
+  - name: results-bucket
+  - name: slack-hook
+  - name: slack-message
+  tasks:
+  - name: slack-notification
+    params:
+    - name: slack-hook
+      value: $(params.slack-hook)
+    - name: slack-message
+      value: $(params.slack-message)+"job kicked off"
+    taskRef:
+      kind: Task
+      name:  slack-notification
+  - name: create-eks-cluster
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: servicerole
+      value: $(params.servicerole)
+    - name: endpoint
+      value: $(params.endpoint)
+    runAfter:
+    - slack-notification
+    taskRef:
+      kind: Task
+      name:  awscli-eks-cluster-create
+    workspaces:
+    - name: config
+      workspace: config
+  - name: create-mng-nodes
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: desired-nodes
+      value: $(params.desired-nodes)
+    - name: host-cluster-node-role-arn
+      value: $(params.host-cluster-node-role-arn)
+    - name: endpoint
+      value: $(params.endpoint)
+    runAfter:
+    - create-eks-cluster
+    taskRef:
+      kind: Task
+      name:  awscli-eks-nodegroup-create
+  - name: create-cw-agent-addon
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
+    runAfter:
+    - create-mng-nodes
+    taskRef:
+      kind: Task
+      name:  eks-addon-cwagent
+  - name: generate
+    params:
+    - name: pods-per-node
+      value: $(params.pods-per-node)
+    - name: nodes-per-namespace
+      value: $(params.nodes-per-namespace)
+    - name: cl2-load-test-throughput
+      value: $(params.cl2-load-test-throughput)
+    - name: results-bucket
+      value: $(params.results-bucket)
+    - name: nodes
+      value: $(params.desired-nodes)
+    runAfter:
+    - create-mng-nodes
+    taskRef:
+      kind: Task
+      name: load
+    workspaces:
+    - name: source
+      workspace: source
+    - name: config
+      workspace: config
+    - name: results
+      workspace: results
+  finally:    
+  - name: teardown
+    params:   
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
+    - name: slack-hook
+      value: $(params.slack-hook)
+    - name: slack-message
+      value: $(params.slack-message)+"job completed"
+    taskRef:
+      kind: Task
+      name:  awscli-eks-cluster-teardown
+  workspaces:
+  - name: config
+  - name: source
+  - name: results

--- a/tests/tasks/addons/cwagent.yaml
+++ b/tests/tasks/addons/cwagent.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: eks-addon-cwagent
+  namespace: tekton-pipelines
+spec:
+  description: |
+    This Task can be used to create a EKS CW Agent Deamonset on EKS cluster
+  params:
+  - name: cluster-name
+    description: The name of the EKS cluster you want to add addons for.
+  - name: region
+    default: "us-west-2"
+    description: The region where the cluster is in.
+  - name: endpoint
+    default: ""
+  steps:
+  - name: create-cw-agent
+    image: alpine/k8s:1.22.6
+    script: |
+      echo "Approving KCM requests"
+      kubectl certificate approve $(kubectl get csr | grep "Pending" | awk '{print $1}')  2>/dev/null || true
+      ENDPOINT_FLAG=""
+      if [ -n "$(params.endpoint)" ]; then
+        ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+      fi
+      aws eks $ENDPOINT_FLAG update-kubeconfig --name $(params.cluster-name) --region $(params.region)
+      #kubectl commands are purely for knowing state of cluster before kicking off the test.
+      kubectl version
+      kubectl config current-context
+      #install cw-agent addon
+      kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
+      kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
+      cat > "./cwagent-configmap.yaml" <<EOL
+      # create configmap for cwagent config
+      apiVersion: v1
+      data:
+        # Configuration is in Json format. No matter what configure change you make,
+        # please keep the Json blob valid.
+        cwagentconfig.json: |
+          {
+            "logs": {
+              "metrics_collected": {
+                "kubernetes": {
+                  "metrics_collection_interval": 60
+                }
+              },
+              "force_flush_interval": 5
+            }
+          }
+      kind: ConfigMap
+      metadata:
+        name: cwagentconfig
+        namespace: amazon-cloudwatch
+      EOL
+      kubectl apply -f ./cwagent-configmap.yaml
+      kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+      kubectl get pods -n amazon-cloudwatch


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Add CW agent to load tests in an effort to come closer to realistic customer workloads.

issue - https://github.com/awslabs/kubernetes-iteration-toolkit/issues/258
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
