### PR TITLE
bug fix

### DIFF
--- a/tests/images/clusterloader2/Dockerfile
+++ b/tests/images/clusterloader2/Dockerfile
@@ -4,7 +4,7 @@ RUN git clone https://github.com/kubernetes/perf-tests
 WORKDIR /go/src/k8s.io/perf-tests/clusterloader2
 RUN GOPROXY=direct GOOS=linux CGO_ENABLED=0  go build -o ./clusterloader ./cmd
 
-FROM alpine:3.15.4
+FROM amazon/aws-cli
 WORKDIR /
 COPY --from=builder /go/src/k8s.io/perf-tests/clusterloader2/clusterloader /clusterloader
 ENTRYPOINT ["/clusterloader"]

--- a/tests/pipelines/eks/awscli-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load.yaml
@@ -22,7 +22,7 @@ spec:
     - name: slack-hook
       value: $(params.slack-hook)
     - name: slack-message
-      value: $(params.slack-message)+"job kicked off"
+      value: "$(params.slack-message) job kicked off"
     taskRef:
       kind: Task
       name:  slack-notification
@@ -91,7 +91,7 @@ spec:
     - name: slack-hook
       value: $(params.slack-hook)
     - name: slack-message
-      value: $(params.slack-message)+"job completed"
+      value: "$(params.slack-message) job completed"
     taskRef:
       kind: Task
       name:  awscli-eks-cluster-teardown

--- a/tests/tasks/notifications/slack.yaml
+++ b/tests/tasks/notifications/slack.yaml
@@ -20,5 +20,5 @@ spec:
       echo "Approving KCM requests"
       kubectl certificate approve $(kubectl get csr | grep "Pending" | awk '{print $1}')  2>/dev/null || true
       if [ -n "$(params.slack-hook)" ]; then
-        curl -H "Content-type: application/json" --data '{"Message": $(params.slack-message)"}' -X POST  $(params.slack-hook)
+        curl -H "Content-type: application/json" --data '{"Message": "$(params.slack-message)"}' -X POST  $(params.slack-hook)
       fi

--- a/tests/tasks/teardown/awscli-eks.yaml
+++ b/tests/tasks/teardown/awscli-eks.yaml
@@ -41,5 +41,5 @@ spec:
     image: alpine/k8s:1.22.6
     script: |
       if [ -n "$(params.slack-hook)" ]; then
-        curl -H "Content-type: application/json" --data '{"Message": $(params.slack-message)"}' -X POST  $(params.slack-hook)
+        curl -H "Content-type: application/json" --data '{"Message": "$(params.slack-message)"}' -X POST  $(params.slack-hook)
       fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- parenthesis was missing in slack notification.
- Looks like clusterloader2 docker image was not tested with aws/eks since this change has been made - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/206/files#diff-097e9f0d378bcb9073bac1233669d42e5a332c1432fd45fb9b4e62ec5ed1e63aL7

Previously tests were using private clusterloader2 image, built and pushed to internal account with amazon/awscli image instead of alpine, which explains why it was working before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
