### PR TITLE
Tekton Tasks and Pipeline to spawn off from Static EKS cluster

### DIFF
--- a/tests/assets/amazon-eks-vpc.json
+++ b/tests/assets/amazon-eks-vpc.json
@@ -1,0 +1,1319 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Amazon EKS Sample VPC - Private and Public subnets",
+    "Parameters": {
+        "VpcBlock1": {
+            "Type": "String",
+            "Default": "10.0.0.0/16",
+            "Description": "The primary CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock2": {
+            "Type": "String",
+            "Default": "10.1.0.0/16",
+            "Description": "The secondary CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock3": {
+            "Type": "String",
+            "Default": "10.2.0.0/16",
+            "Description": "The secondary CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock4": {
+            "Type": "String",
+            "Default": "10.3.0.0/16",
+            "Description": "The secondary CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock5": {
+            "Type": "String",
+            "Default": "10.4.0.0/16",
+            "Description": "The CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock6": {
+            "Type": "String",
+            "Default": "10.5.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock7": {
+            "Type": "String",
+            "Default": "10.6.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock8": {
+            "Type": "String",
+            "Default": "10.7.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock9": {
+            "Type": "String",
+            "Default": "10.8.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock10": {
+            "Type": "String",
+            "Default": "10.9.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock11": {
+            "Type": "String",
+            "Default": "10.10.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "VpcBlock12": {
+            "Type": "String",
+            "Default": "10.11.0.0/16",
+            "Description": "The  CIDR range for the VPC. This should be a valid private (RFC 1918) CIDR range."
+        },
+        "PublicSubnet01Block": {
+            "Type": "String",
+            "Default": "10.0.0.0/16",
+            "Description": "CidrBlock for public subnet 01 within the VPC"
+        },
+        "PublicSubnet02Block": {
+            "Type": "String",
+            "Default": "10.1.0.0/16",
+            "Description": "CidrBlock for public subnet 02 within the VPC"
+        },
+        "PublicSubnet03Block": {
+            "Type": "String",
+            "Default": "10.2.0.0/16",
+            "Description": "CidrBlock for public subnet 03 within the VPC"
+        },
+        "PublicSubnet04Block": {
+            "Type": "String",
+            "Default": "10.3.0.0/16",
+            "Description": "CidrBlock for public subnet 04 within the VPC"
+        },
+        "PrivateSubnet01Block": {
+            "Type": "String",
+            "Default": "10.4.0.0/16",
+            "Description": "CidrBlock for private subnet 01 within the VPC"
+        },
+        "PrivateSubnet02Block": {
+            "Type": "String",
+            "Default": "10.5.0.0/16",
+            "Description": "CidrBlock for private subnet 02 within the VPC"
+        },
+        "PrivateSubnet03Block": {
+            "Type": "String",
+            "Default": "10.6.0.0/16",
+            "Description": "CidrBlock for private subnet 03 within the VPC"
+        },
+        "PrivateSubnet04Block": {
+            "Type": "String",
+            "Default": "10.7.0.0/16",
+            "Description": "CidrBlock for private subnet 04 within the VPC"
+        },
+        "PrivateSubnet05Block": {
+            "Type": "String",
+            "Default": "10.8.0.0/16",
+            "Description": "CidrBlock for private subnet 05 within the VPC"
+        },
+        "PrivateSubnet06Block": {
+            "Type": "String",
+            "Default": "10.9.0.0/16",
+            "Description": "CidrBlock for private subnet 06 within the VPC"
+        },
+        "PrivateSubnet07Block": {
+            "Type": "String",
+            "Default": "10.10.0.0/16",
+            "Description": "CidrBlock for private subnet 07 within the VPC"
+        },
+        "PrivateSubnet08Block": {
+            "Type": "String",
+            "Default": "10.11.0.0/16",
+            "Description": "CidrBlock for private subnet 08 within the VPC"
+        }
+    },
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Worker Network Configuration"
+                    },
+                    "Parameters": [
+                        "VpcBlock1",
+                        "VpcBlock2",
+                        "VpcBlock3",
+                        "VpcBlock4",
+                        "VpcBlock5",
+                        "VpcBlock6",
+                        "VpcBlock7",
+                        "VpcBlock8",
+                        "VpcBlock9",
+                        "VpcBlock10",
+                        "VpcBlock11",
+                        "VpcBlock12",
+                        "PublicSubnet01Block",
+                        "PublicSubnet02Block",
+                        "PublicSubnet03Block",
+                        "PublicSubnet04Block",
+                        "PrivateSubnet01Block",
+                        "PrivateSubnet02Block",
+                        "PrivateSubnet03Block",
+                        "PrivateSubnet04Block",
+                        "PrivateSubnet05Block",
+                        "PrivateSubnet06Block",
+                        "PrivateSubnet07Block",
+                        "PrivateSubnet08Block"
+                    ]
+                }
+            ]
+        }
+    },
+    "Conditions": {
+        "HasMoreThan2Azs": {
+            "Fn::Not": [
+                {
+                    "Fn::Or": [
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "cn-north-1"
+                            ]
+                        },
+                        {
+                            "Fn::Equals": [
+                                {
+                                    "Ref": "AWS::Region"
+                                },
+                                "us-isob-east-1"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "Resources": {
+        "VPC": {
+            "Type": "AWS::EC2::VPC",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock1"
+                },
+                "EnableDnsSupport": true,
+                "EnableDnsHostnames": true,
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-VPC"
+                        }
+                    }
+                ]
+            }
+        },
+        "VPCCIDRBlock2": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock2"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock3": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock3"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock4": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock4"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock5": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock5"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock6": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock6"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock7": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock7"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock8": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock8"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock9": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock9"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock10": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock10"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock11": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock11"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "VPCCIDRBlock12": {
+            "Type": "AWS::EC2::VPCCidrBlock",
+            "Properties": {
+                "CidrBlock": {
+                    "Ref": "VpcBlock12"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "InternetGateway": {
+            "Type": "AWS::EC2::InternetGateway"
+        },
+        "VPCGatewayAttachment": {
+            "Type": "AWS::EC2::VPCGatewayAttachment",
+            "Properties": {
+                "InternetGatewayId": {
+                    "Ref": "InternetGateway"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        },
+        "PublicRouteTable": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Public Subnets"
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Public"
+                    }
+                ]
+            }
+        },
+        "PrivateRouteTable01": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Private Subnet AZ1"
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private01"
+                    }
+                ]
+            }
+        },
+        "PrivateRouteTable02": {
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Private Subnet AZ2"
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private02"
+                    }
+                ]
+            }
+        },
+        "PrivateRouteTable03": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Private Subnet AZ3"
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private03"
+                    }
+                ]
+            }
+        },
+        "PrivateRouteTable04": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::RouteTable",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": "Private Subnet AZ4"
+                    },
+                    {
+                        "Key": "Network",
+                        "Value": "Private04"
+                    }
+                ]
+            }
+        },
+
+        "PublicRoute": {
+            "DependsOn": "VPCGatewayAttachment",
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "GatewayId": {
+                    "Ref": "InternetGateway"
+                }
+            }
+        },
+        "PrivateRoute01": {
+            "DependsOn": [
+                "VPCGatewayAttachment",
+                "NatGateway01"
+            ],
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable01"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "NatGatewayId": {
+                    "Ref": "NatGateway01"
+                }
+            }
+        },
+        "PrivateRoute02": {
+            "DependsOn": [
+                "VPCGatewayAttachment",
+                "NatGateway02"
+            ],
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable02"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "NatGatewayId": {
+                    "Ref": "NatGateway02"
+                }
+            }
+        },
+        "PrivateRoute03": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "VPCGatewayAttachment",
+                "NatGateway03"
+            ],
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable03"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "NatGatewayId": {
+                    "Ref": "NatGateway03"
+                }
+            }
+        },
+        "PrivateRoute04": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "VPCGatewayAttachment",
+                "NatGateway04"
+            ],
+            "Type": "AWS::EC2::Route",
+            "Properties": {
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable04"
+                },
+                "DestinationCidrBlock": "0.0.0.0/0",
+                "NatGatewayId": {
+                    "Ref": "NatGateway04"
+                }
+            }
+        },
+        
+        "NatGateway01": {
+            "DependsOn": [
+                "NatGatewayEIP1",
+                "PublicSubnet01",
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "NatGatewayEIP1",
+                        "AllocationId"
+                    ]
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet01"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-NatGatewayAZ1"
+                        }
+                    }
+                ]
+            }
+        },
+        "NatGateway02": {
+            "DependsOn": [
+                "NatGatewayEIP2",
+                "PublicSubnet02",
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "NatGatewayEIP2",
+                        "AllocationId"
+                    ]
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet02"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-NatGatewayAZ2"
+                        }
+                    }
+                ]
+            }
+        },
+        "NatGateway03": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "NatGatewayEIP3",
+                "PublicSubnet03",
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "NatGatewayEIP3",
+                        "AllocationId"
+                    ]
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet03"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-NatGatewayAZ3"
+                        }
+                    }
+                ]
+            }
+        },
+        "NatGateway04": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "NatGatewayEIP4",
+                "PublicSubnet04",
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::NatGateway",
+            "Properties": {
+                "AllocationId": {
+                    "Fn::GetAtt": [
+                        "NatGatewayEIP4",
+                        "AllocationId"
+                    ]
+                },
+                "SubnetId": {
+                    "Ref": "PublicSubnet04"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-NatGatewayAZ4"
+                        }
+                    }
+                ]
+            }
+        },
+
+        "NatGatewayEIP1": {
+            "DependsOn": [
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::EIP",
+            "Properties": {
+                "Domain": "vpc"
+            }
+        },
+        "NatGatewayEIP2": {
+            "DependsOn": [
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::EIP",
+            "Properties": {
+                "Domain": "vpc"
+            }
+        },
+        "NatGatewayEIP3": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::EIP",
+            "Properties": {
+                "Domain": "vpc"
+            }
+        },
+        "NatGatewayEIP4": {
+            "Condition": "HasMoreThan2Azs",
+            "DependsOn": [
+                "VPCGatewayAttachment"
+            ],
+            "Type": "AWS::EC2::EIP",
+            "Properties": {
+                "Domain": "vpc"
+            }
+        },
+        "PublicSubnet01": {
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Subnet 01"
+            },
+            "Properties": {
+                "MapPublicIpOnLaunch": true,
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnet01Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PublicSubnet01"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PublicSubnet02": {
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Subnet 02"
+            },
+            "Properties": {
+                "MapPublicIpOnLaunch": true,
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "1",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnet02Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PublicSubnet02"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PublicSubnet03": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Subnet 03"
+            },
+            "Properties": {
+                "MapPublicIpOnLaunch": true,
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "2",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnet03Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PublicSubnet03"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PublicSubnet04": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Subnet 04"
+            },
+            "Properties": {
+                "MapPublicIpOnLaunch": true,
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "3",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PublicSubnet04Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PublicSubnet04"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet01": {
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 01"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet01Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet01"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet02": {
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 02"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "1",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet02Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet02"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet03": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 03"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "2",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet03Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet03"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet04": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 04"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "3",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet04Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet04"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet05": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 05"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "0",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet05Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet05"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet06": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 06"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "1",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet06Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet06"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet07": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 07"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "2",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet07Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet07"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PrivateSubnet08": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::Subnet",
+            "Metadata": {
+                "Comment": "Private Subnet 08"
+            },
+            "Properties": {
+                "AvailabilityZone": {
+                    "Fn::Select": [
+                        "3",
+                        {
+                            "Fn::GetAZs": {
+                                "Ref": "AWS::Region"
+                            }
+                        }
+                    ]
+                },
+                "CidrBlock": {
+                    "Ref": "PrivateSubnet08Block"
+                },
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": {
+                            "Fn::Sub": "${AWS::StackName}-PrivateSubnet08"
+                        }
+                    },
+                    {
+                        "Key": "kubernetes.io/role/internal-elb",
+                        "Value": 1
+                    }
+                ]
+            }
+        },
+        "PublicSubnet01RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet01"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            }
+        },
+        "PublicSubnet02RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet02"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            }
+        },
+        "PublicSubnet03RouteTableAssociation": {
+            "Condition": "HasMoreThan2Azs",
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet03"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            }
+        },
+        "PublicSubnet04RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PublicSubnet04"
+                },
+                "RouteTableId": {
+                    "Ref": "PublicRouteTable"
+                }
+            }
+        },
+        "PrivateSubnet01RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet01"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable01"
+                }
+            }
+        },
+        "PrivateSubnet02RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet02"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable02"
+                }
+            }
+        },
+        "PrivateSubnet03RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet03"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable03"
+                }
+            }
+        },
+        "PrivateSubnet04RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet04"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable04"
+                }
+            }
+        },
+        "PrivateSubnet05RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet05"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable01"
+                }
+            }
+        },
+        "PrivateSubnet06RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet06"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable02"
+                }
+            }
+        },
+        "PrivateSubnet07RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet07"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable03"
+                }
+            }
+        },
+        "PrivateSubnet08RouteTableAssociation": {
+            "Type": "AWS::EC2::SubnetRouteTableAssociation",
+            "Properties": {
+                "SubnetId": {
+                    "Ref": "PrivateSubnet08"
+                },
+                "RouteTableId": {
+                    "Ref": "PrivateRouteTable04"
+                }
+            }
+        },
+        "ControlPlaneSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Cluster communication with worker nodes",
+                "VpcId": {
+                    "Ref": "VPC"
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "SubnetIds": {
+            "Description": "Subnets IDs in the VPC",
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    [
+                        {
+                            "Ref": "PublicSubnet01"
+                        },
+                        {
+                            "Ref": "PublicSubnet02"
+                        },
+                        {
+                            "Ref": "PublicSubnet03"
+                        },
+                        {
+                            "Ref": "PublicSubnet04"
+                        },
+                        {
+                            "Ref": "PrivateSubnet01"
+                        },
+                        {
+                            "Ref": "PrivateSubnet02"
+                        },
+                        {
+                            "Ref": "PrivateSubnet03"
+                        },
+                        {
+                            "Ref": "PrivateSubnet04"
+                        },
+                        {
+                            "Ref": "PrivateSubnet05"
+                        },
+                        {
+                            "Ref": "PrivateSubnet06"
+                        },
+                        {
+                            "Ref": "PrivateSubnet07"
+                        },
+                        {
+                            "Ref": "PrivateSubnet08"
+                        }
+                    ]
+                ]
+            }
+        },
+        "SecurityGroups": {
+            "Description": "Security group for the cluster control plane communication with worker nodes",
+            "Value": {
+                "Fn::Join": [
+                    ",",
+                    [
+                        {
+                            "Ref": "ControlPlaneSecurityGroup"
+                        }
+                    ]
+                ]
+            }
+        },
+        "VpcId": {
+            "Description": "The VPC Id",
+            "Value": {
+                "Ref": "VPC"
+            }
+        }
+    }
+}

--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -4,6 +4,9 @@ metadata:
   name: awscli-eks-cl2loadtest
   namespace: tekton-pipelines
 spec:
+  description: |
+    This pipeline sends slack notifcation before it spins up an EKS cluster with in it's own VPC 
+    and runs cl2 loadtest and upload results to s3 and tearsdown the cluster and sends slack notification.
   params:
   - name: cluster-name
   - name: endpoint
@@ -16,6 +19,7 @@ spec:
   - name: results-bucket
   - name: slack-hook
   - name: slack-message
+  - name: vpc-stack-name
   tasks:
   - name: slack-notification
     params:
@@ -26,6 +30,15 @@ spec:
     taskRef:
       kind: Task
       name:  slack-notification
+  - name: awscli-vpc-create
+    params:
+    - name: stack-name
+      value: $(params.vpc-stack-name)
+    - name: vpc-cfn-url
+      value: "$(params.vpc-cfn-url)"
+    taskRef:
+      kind: Task
+      name:  awscli-vpc-create
   - name: create-eks-cluster
     params:
     - name: cluster-name
@@ -34,11 +47,13 @@ spec:
       value: $(params.servicerole)
     - name: endpoint
       value: $(params.endpoint)
+    - name: vpc-stack-name
+      value: $(params.vpc-stack-name)
     runAfter:
-    - slack-notification
+    - awscli-vpc-create
     taskRef:
       kind: Task
-      name:  awscli-eks-cluster-create
+      name:  awscli-eks-cluster-create-with-vpc-stack
     workspaces:
     - name: config
       workspace: config

--- a/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: awscli-eks-cluster-create-with-vpc-stack
+  namespace: tekton-pipelines  
+spec:
+  description: |
+    Create an EKS cluster.
+    This Task can be used to create an EKS cluster for a given service role, region in an AWS account 
+  params:
+  - name: cluster-name
+    description: The name of the EKS cluster you want to spin.
+  - name: kubernetes-version
+    default: "1.23"
+    description: The EKS version to install.
+  - name: region
+    default: "us-west-2"
+    description: The region where the cluster is in.
+  - name: endpoint
+    default: ""
+    description: "aws eks enpoint to create clusters against"
+  - name: servicerole
+    description: servicerole arn to be used for eks cluster to perform operations in customer account to setup cluster
+  - name: vpc-stack-name
+    description: The name of the VPC name you want to use for EKS cluster.
+  steps:
+  - name: create-eks
+    image: alpine/k8s:1.22.6
+    script: |
+      echo "Approving KCM requests"
+      kubectl certificate approve $(kubectl get csr | grep "Pending" | awk '{print $1}')  2>/dev/null || true
+      ENDPOINT_FLAG=""
+      if [ -n "$(params.endpoint)" ]; then
+        ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+      fi
+      CREATED_CLUSTER=$(aws eks $ENDPOINT_FLAG list-clusters --region $(params.region) --query 'clusters[?@==`'$(params.cluster-name)'`]' --output text )
+      echo "CREATED_CLUSTER=$CREATED_CLUSTER"
+
+      subnets=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.vpc-stack-name) --query='Stacks[].Outputs[?OutputKey==`SubnetIds`].OutputValue' --output text | sed -e 's/ /,/')
+      echo "subnets=$subnets"
+      sg=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.vpc-stack-name) --query='Stacks[].Outputs[?OutputKey==`SecurityGroups`].OutputValue' --output text)
+      echo "securitygroup=$sg"
+      
+      if [ "$CREATED_CLUSTER" == "" ]; then
+        aws eks create-cluster --name $(params.cluster-name) --region $(params.region) --kubernetes-version $(params.kubernetes-version) --role-arn $(params.servicerole) --resources-vpc-config subnetIds=$subnets,securityGroupIds=$sg $ENDPOINT_FLAG
+      fi
+      aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name) 
+      aws eks $ENDPOINT_FLAG update-kubeconfig --name $(params.cluster-name) --region $(params.region)
+      # enable PD on the cluster 
+      kubectl set env ds aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true

--- a/tests/tasks/setup/eks/awscli-mng.yaml
+++ b/tests/tasks/setup/eks/awscli-mng.yaml
@@ -55,6 +55,7 @@ spec:
       create_dp()
       {
         CREATED_NODEGROUP=$(aws eks $ENDPOINT_FLAG --region $(params.region) list-nodegroups --cluster-name $(params.cluster-name)  --query 'nodegroups[?@==`'$asg_name-$1'`]' --output text)
+        #ToDo: paramterize instance-types
         if [ "$CREATED_NODEGROUP" == "" ]; then
           #create node group
           aws eks $ENDPOINT_FLAG create-nodegroup \
@@ -62,7 +63,7 @@ spec:
           --nodegroup-name $asg_name-$1 \
           --node-role $(params.host-cluster-node-role-arn) \
           --region $(params.region) \
-          --instance-types m5.4xlarge m4.4xlarge m5d.4xlarge m5a.4xlarge m5ad.4xlarge \
+          --instance-types c5.large m5.large r5.large t3.large t3a.large c5a.large m5a.large r5a.large \
           --scaling-config minSize=$(params.min-nodes),maxSize=$2,desiredSize=$2 \
           --subnets $NG_SUBNETS
         fi

--- a/tests/tasks/setup/eks/awscli-vpc.yaml
+++ b/tests/tasks/setup/eks/awscli-vpc.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: awscli-vpc-create
+  namespace: tekton-pipelines 
+spec:
+  description: |
+    Creates VPC.
+    This Task can be used to create VPC resources that could be used for EKS clusters. This stack outputs resources SubnetIds, SecurityGroups, VpcId.
+  params:
+  - name: stack-name
+    description: The name of the VPC name you want to spin.
+  - name: vpc-cfn-url
+    description: The url of the CFN YAML/JSON to create VPC resources 
+  - name: region
+    default: "us-west-2"
+  steps:
+  - name: create-vpc
+    image: alpine/k8s:1.22.6
+    script: |
+      #!/usr/bin/env bash
+      echo "Approving KCM requests"
+      kubectl certificate approve $(kubectl get csr | grep "Pending" | awk '{print $1}')  2>/dev/null || true
+      curl -s $(params.vpc-cfn-url) -o ./amazon-vpc-eks
+      aws cloudformation --region $(params.region) deploy --stack-name $(params.stack-name)  --template-file file://$(pwd)/amazon-vpc-eks 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Tekton Tasks  that creates VPC and EKS cluster using VPC and Pipeline. Gives ability to spawn off EKS test clusters from Static EKS cluster.

### testing 
https://tiny.amazon.com/1hjkn7p3w/IsenLink
https://5k.scalability.eks.aws.dev/#/namespaces/tekton-pipelines/taskruns/awscli-vpc-create-run-1660664577883-r-dmbst?step=create-vpc
https://5k.scalability.eks.aws.dev/#/namespaces/tekton-pipelines/taskruns/awscli-eks-cluster-create-with-vpc-stack-run-1660716812411m2547?step=create-eks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
