### PR TITLE
change tektondahboard service type to NodePort

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -79,18 +79,6 @@ spec:
         data: 
           default-task-run-workspace-binding: |
             emptyDir: {}
-    - target:
-        kind: Service
-        name: tekton-dashboard
-        namespace: tekton-pipelines
-      patch: |-
-        apiVersion: v1
-        kind: Service
-        metadata:
-          name: tekton-dashboard
-          namespace: tekton-pipelines
-        spec:
-          type: NodePort
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -167,3 +155,15 @@ spec:
               tolerations:
                 - key: CriticalAddonsOnly
                   operator: Exists
+    - target:
+        kind: Service
+        name: tekton-dashboard
+        namespace: tekton-pipelines
+      patch: |-
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: tekton-dashboard
+          namespace: tekton-pipelines
+        spec:
+          type: NodePort


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/252
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/253

Description of changes:

- change service type of tekton-dashboard to Nodeport

# testing 
```
- dev-dsk-hakuna-2c-0fa5574b % kubectl get services -n tekton-pipelines
NAME                          TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                              AGE
tekton-dashboard              NodePort    172.20.240.237   <none>        9097:31669/TCP                       31h
tekton-pipelines-controller   ClusterIP   172.20.65.59     <none>        9090/TCP,8008/TCP,8080/TCP           31h
tekton-pipelines-webhook      ClusterIP   172.20.238.21    <none>        9090/TCP,8008/TCP,443/TCP,8080/TCP   31h
tekton-triggers-controller    ClusterIP   172.20.171.72    <none>        9000/TCP                             31h
tekton-triggers-webhook       ClusterIP   172.20.204.191   <none>        443/TCP                              31h
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
