### PR TITLE
up the default infra timeout

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -79,6 +79,7 @@ spec:
         data: 
           default-task-run-workspace-binding: |
             emptyDir: {}
+          default-timeout-minutes: "180"
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Set a default timeout on the Infrastructure tekton tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
