### PR TITLE
Make tekton load generator independent 

### DIFF
--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -137,6 +137,7 @@ export class KITInfrastructure extends Stack {
                     "eks:*",
                     "pricing:GetProducts",
                     "sts:AssumeRole",
+                    "s3:*"
                 ],
             }),
         ],

--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -81,6 +81,10 @@ spec:
       value: $(params.results-bucket)
     - name: nodes
       value: $(params.desired-nodes)
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
     runAfter:
     - create-mng-nodes
     taskRef:

--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -24,6 +24,14 @@ spec:
     default: "1000"
   - name: results-bucket
     description: "Results bucket with path of s3 to upload results"
+  - name: region
+    default: "us-west-2"
+    description: The region where the cluster is in.
+  - name: endpoint
+    default: ""
+    description: "aws eks enpoint to create clusters against"
+  - name: cluster-name
+    description: The name of the EKS cluster you want to spin.
   workspaces:
   - name: source
   - name: results
@@ -57,7 +65,12 @@ spec:
     image: public.ecr.aws/kit/clusterloader2:0213bea
     onError: continue
     script: |
-      ENABLE_EXEC_SERVICE=false /clusterloader --kubeconfig=$(workspaces.config.path)/kubeconfig --testconfig=$(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path) --alsologtostderr --v=2
+      ENDPOINT_FLAG=""
+      if [ -n "$(params.endpoint)" ]; then
+        ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+      fi
+      aws eks $ENDPOINT_FLAG update-kubeconfig --name $(params.cluster-name) --region $(params.region)
+      ENABLE_EXEC_SERVICE=false /clusterloader --kubeconfig=/root/.kube/config --testconfig=$(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path) --alsologtostderr --v=2
     timeout: 30000s
   - name: upload-results
     image: alpine/k8s:1.22.6


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/253
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/252

Description of changes:
- Make tekton load generator an independent task 
- add permissions to create/upload to s3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
