### PR TITLE
fix kit infras timeouts and block device mappings

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/provisioner.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/provisioner.yaml
@@ -9,6 +9,11 @@ spec:
     aws-cdk:subnet-type: Private
   securityGroupSelector:
     kit.sh/stack: KITInfrastructure
+  blockDeviceMappings:
+  - deviceName: /dev/xvda
+    ebs:
+      volumeSize: 100Gi
+      volumeType: gp3
 ---
 apiVersion: karpenter.sh/v1alpha5
 kind: Provisioner

--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -79,6 +79,7 @@ spec:
         data: 
           default-task-run-workspace-binding: |
             emptyDir: {}
+          default-timeout-minutes: "240"
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
 - Fixes KIT infra timeouts (which was accidentally reverted in https://github.com/awslabs/kubernetes-iteration-toolkit/pull/280/files) 
 - Add block device mappings so that disks don't fill up from the default 20Gi

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
