### PR TITLE
Make cl2 tekton task tie to perf-tests/clusterloader2 repo release branches

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,13 @@
+# Kubernetes Iteration Toolkit Tests with Tekton
+
+### Overview:
+Tekton is a powerful and flexible open-source framework for creating CI/CD systems, allowing developers to build, test, and deploy across cloud providers and on-premise systems.
+
+
+
+### Test Images
+
+Tekton tasks can leverage image like clusterloader2 to perform various kinds of tests like load, pod-density on K8s cluster on KIT infra. 
+To build the docker image for clusterloader2 use the below command which takes `branch` as a build arg which lets us build clusterloader2 for a given branch on this repo[here](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2)
+
+- docker build --build-arg branch=release-1.23 ./images/clusterloader2/

--- a/tests/images/clusterloader2/Dockerfile
+++ b/tests/images/clusterloader2/Dockerfile
@@ -1,6 +1,9 @@
 FROM golang:1.16.4 AS builder
 WORKDIR /go/src/k8s.io
 RUN git clone https://github.com/kubernetes/perf-tests
+WORKDIR perf-tests
+RUN git fetch origin --verbose --tags
+RUN git checkout $branch
 WORKDIR /go/src/k8s.io/perf-tests/clusterloader2
 RUN GOPROXY=direct GOOS=linux CGO_ENABLED=0  go build -o ./clusterloader ./cmd
 

--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -10,6 +10,9 @@ spec:
   - name: giturl
     description: "git url to clone the package"
     default: https://github.com/kubernetes/perf-tests.git
+  - name: cl2-branch
+    description: "The branch of clusterloader2 you want to use"
+    default: "release-1.23"
   - name: nodes-per-namespace
     description: "nodes per namespace to get created for load test "
     default: "100"
@@ -39,7 +42,12 @@ spec:
   - name: git-clone      
     image: alpine/git
     workingDir: $(workspaces.source.path)
-    args: ["clone", "$(params.giturl)"]
+    script: |
+      git clone $(params.giturl)
+      cd $(workspaces.source.path)/perf-tests/
+      git fetch origin --verbose --tags
+      git checkout $(params.cl2-branch)
+      git branch
   - name: prepare-loadtest
     image: alpine/k8s:1.22.6
     workingDir: $(workspaces.source.path)
@@ -70,6 +78,7 @@ spec:
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
       fi
       aws eks $ENDPOINT_FLAG update-kubeconfig --name $(params.cluster-name) --region $(params.region)
+      cat $(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml
       ENABLE_EXEC_SERVICE=false /clusterloader --kubeconfig=/root/.kube/config --testconfig=$(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path) --alsologtostderr --v=2
     timeout: 30000s
   - name: upload-results

--- a/tests/tasks/setup/kitctl/dataplane.yaml
+++ b/tests/tasks/setup/kitctl/dataplane.yaml
@@ -49,4 +49,3 @@ spec:
           sleep 5
       done 
       kubectl --kubeconfig=/tmp/kubeconfig get nodes
-


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/issues/287

Description of changes:
- fix for this - https://github.com/awslabs/kubernetes-iteration-toolkit/issues/287
- also fix example tekton tasks that are obsolete w.r.t current state of KIT repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
