### PR TITLE
Add public subnets in all AZs

### DIFF
--- a/docs/how-to-use-kit.md
+++ b/docs/how-to-use-kit.md
@@ -109,6 +109,8 @@ As part of these tests, I want to capture-
     - latency for the API server calls is not impacted and SLO’s are not breached.
     - metrics for core Kubernetes components like scheduler, KCM, etcd etc.
 
+> Note: Kit environment created using `kitctl` supports 64k IP addresses. In case your use case needs kitctl to support additional IPs, feel free to open a github issue.
+
 ## Key Terms
 
 **KIT/clusters or guest clusters -** These are rapid prototyping vanilla Kubernetes clusters provisioned using using EKS-distro images. They take about 3-4 minutes to provision on ec2 nodes and less than 30 seconds to update their configurations. These clusters are provisioned by KIT-operator running in the KIT environment

--- a/substrate/cmd/kitctl/bootstrap.go
+++ b/substrate/cmd/kitctl/bootstrap.go
@@ -51,19 +51,19 @@ func bootstrap(cmd *cobra.Command, args []string) {
 	start := time.Now()
 	name := parseName(ctx, args)
 	logging.FromContext(ctx).Infof("Bootstrapping %q", name)
-	vpcCidrs := []string{"10.0.0.0/16", "10.1.0.0/16", "10.2.0.0/16", "10.3.0.0/16", "10.4.0.0/16"}
 	if err := substrate.NewController(ctx).Reconcile(ctx, &v1alpha1.Substrate{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 
 		Spec: v1alpha1.SubstrateSpec{
-			VPC:          &v1alpha1.VPCSpec{CIDR: vpcCidrs},
+			VPC:          &v1alpha1.VPCSpec{CIDR: []string{"10.0.0.0/16"}},
 			InstanceType: aws.String("r6g.8xlarge"),
 			Subnets: []*v1alpha1.SubnetSpec{
-				{Zone: "us-west-2a", CIDR: vpcCidrs[0]},
-				{Zone: "us-west-2b", CIDR: vpcCidrs[1]},
-				{Zone: "us-west-2c", CIDR: vpcCidrs[2]},
-				{Zone: "us-west-2a", CIDR: vpcCidrs[3], Public: true},
-				{Zone: "us-west-2b", CIDR: vpcCidrs[4], Public: true},
+				{Zone: "us-west-2a", CIDR: "10.0.1.0/24"},
+				{Zone: "us-west-2b", CIDR: "10.0.2.0/24"},
+				{Zone: "us-west-2c", CIDR: "10.0.3.0/24"},
+				{Zone: "us-west-2a", CIDR: "10.0.100.0/24", Public: true},
+				{Zone: "us-west-2b", CIDR: "10.0.101.0/24", Public: true},
+				{Zone: "us-west-2c", CIDR: "10.0.102.0/24", Public: true},
 			},
 		},
 	}); err != nil {


### PR DESCRIPTION
Issue #, if available:
Fixes an issue when ELB is created in 2 AZs (a and b) because we have 2 public subnets, but master instance is in third AZ (c). ELB is not able to reach to the third master instance

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
