### PR TITLE
attempt to fix sec vulnerability

### DIFF
--- a/substrate/go.mod
+++ b/substrate/go.mod
@@ -145,7 +145,7 @@ require (
 	k8s.io/component-base v0.24.3 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
-	k8s.io/kube-proxy v0.0.0 // indirect
+	k8s.io/kube-proxy v0.24.3 // indirect
 	k8s.io/kubectl v0.24.2 // indirect
 	k8s.io/kubelet v0.0.0 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect


### PR DESCRIPTION
Issue #, if available:
https://github.com/awslabs/kubernetes-iteration-toolkit/security/dependabot/17 

It looks like this wasn't updated as part of last go dependencies  update here - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/266/files#diff-d3389f59b438efb012df336e7eb63d4fbda56a63a60fec8a1fae451cea3df976L147

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
