### PR TITLE
add hostpki volume mount

### DIFF
--- a/operator/pkg/controllers/master/kubecontrollermanager.go
+++ b/operator/pkg/controllers/master/kubecontrollermanager.go
@@ -83,6 +83,7 @@ func kcmLabels(clustername string) map[string]string {
 
 func kcmPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+	hostPathDirectory := v1.HostPathDirectory
 	return kcmPodSpecForVersion(controlPlane.Spec.KubernetesVersion, &v1.PodSpec{
 		TerminationGracePeriodSeconds: aws.Int64(1),
 		HostNetwork:                   true,
@@ -122,6 +123,10 @@ func kcmPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 				"--v=2",
 			},
 			VolumeMounts: []v1.VolumeMount{{
+				Name:      "hostpki",
+				MountPath: "/etc/pki",
+				ReadOnly:  true,
+			}, {
 				Name:      "ca-certs",
 				MountPath: "/etc/ssl/certs",
 				ReadOnly:  true,
@@ -162,6 +167,14 @@ func kcmPodSpecFor(controlPlane *v1alpha1.ControlPlane) v1.PodSpec {
 			},
 		}},
 		Volumes: []v1.Volume{{
+			Name: "hostpki",
+			VolumeSource: v1.VolumeSource{
+				HostPath: &v1.HostPathVolumeSource{
+					Path: "/etc/pki",
+					Type: &hostPathDirectory,
+				},
+			},
+		}, {
 			Name: "ca-certs",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{


### PR DESCRIPTION
It appears the kit operator sometimes needs the hostpki.
This change was advised by @prateekgogia a few weeks ago.