### PR TITLE
Unique package name for infra and add license

### DIFF
--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "infra",
+  "name": "kit-infra-cdk",
+  "license": "Apache-2",
   "version": "0.1.0",
   "bin": {
-    "infra": "bin/infra.js"
+    "infra": "bin/kit-infrastructure.ts"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Gives the infra package a unique name so that it can be used by other packages
* Adds a license field for the license to show up in registries
* Corrects the bin location


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
