### PR TITLE
add a task to generate a timestamp

### DIFF
--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -21,6 +21,9 @@ spec:
   - name: slack-message
   - name: vpc-cfn-url
   tasks:
+  - name: timestamp
+    taskRef:
+      name: timestamp
   - name: slack-notification
     params:
     - name: slack-hook

--- a/tests/tasks/timestamp/timestamp.yaml
+++ b/tests/tasks/timestamp/timestamp.yaml
@@ -1,0 +1,15 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: timestamp
+  namespace: tekton-pipelines
+spec:
+  results:
+    - name: timestamp
+      description: The current date in unix timestamp format
+  steps:
+    - name: date
+      image: bash:latest
+      script: |
+        #!/usr/bin/env bash
+        date +%s | tee $(results.timestamp.path)


### PR DESCRIPTION
It can be used as part of the `results-bucket` path to satisfy the build-id requirement of perfdash.