### PR TITLE
Use the kubectl image that contains curl

### DIFF
--- a/tests/tasks/setup/kitctl/controlplane.yaml
+++ b/tests/tasks/setup/kitctl/controlplane.yaml
@@ -46,7 +46,7 @@ spec:
     description: Kubernetes version for the guest cluster 
   steps:
   - name: setup-control-plane
-    image: bitnami/kubectl
+    image: bitnami/kubectl:1.24.5 # curl was removed in more recent versions
     script: |
       #!/bin/bash
       echo "Approving KCM requests"


### PR DESCRIPTION
tests/tasks/setup/kitctl/controlplane.yaml uses curl to probe the healthz endpoint.
It's not trivial to install curl when we are already running it as user "nobody".