### PR TITLE
rename package to kit-infrastructure

### DIFF
--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "kit-infra-cdk",
+  "name": "kit-infrastructure",
   "license": "Apache-2",
   "version": "0.1.0",
   "bin": {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* Renames package before publishing npm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
