### PR TITLE
add a task for installing fluentbit addon

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -57,6 +57,17 @@ spec:
     taskRef:
       kind: Task
       name:  awscli-eks-nodegroup-create
+  - name: install-fluentbit-addon
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
+    runAfter:
+    - create-mng-nodes
+    taskRef:
+      kind: Task
+      name: eks-addon-fluentbit
   - name: create-cw-agent-addon
     params:
     - name: cluster-name
@@ -81,7 +92,8 @@ spec:
     - name: nodes
       value: $(params.desired-nodes)
     runAfter:
-    - create-mng-nodes
+    - install-fluentbit-addon
+    - create-cw-agent-addon
     taskRef:
       kind: Task
       name: load

--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -73,6 +73,17 @@ spec:
     taskRef:
       kind: Task
       name:  awscli-eks-nodegroup-create
+  - name: install-fluentbit-addon
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
+    runAfter:
+    - create-mng-nodes
+    taskRef:
+      kind: Task
+      name: eks-addon-fluentbit
   - name: generate
     params:
     - name: pods-per-node
@@ -90,7 +101,7 @@ spec:
     - name: endpoint
       value: $(params.endpoint)
     runAfter:
-    - create-mng-nodes
+    - install-fluentbit-addon
     taskRef:
       kind: Task
       name: load

--- a/tests/pipelines/eks/upstream-load.yaml
+++ b/tests/pipelines/eks/upstream-load.yaml
@@ -71,8 +71,17 @@ spec:
     workspaces:
       - name: config    
         workspace: config
+  - name: install-fluentbit-addon
+    params:
+    - name: cluster-name
+      value: $(params.cluster-name)
+    runAfter:
+    - create-eks-cluster
+    taskRef:
+      kind: Task
+      name: eks-addon-fluentbit
   - name: generate
-    runAfter: [create-eks-cluster]
+    runAfter: [install-fluentbit-addon]
     taskRef:
       name: load
     params:

--- a/tests/tasks/addons/fluentbit.yaml
+++ b/tests/tasks/addons/fluentbit.yaml
@@ -48,5 +48,4 @@ spec:
       EOL
       kubectl apply -f ./fluentbit-configmap.yaml
       kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
-      sleep 30
-      kubectl get pods -n amazon-cloudwatch
+      kubectl rollout status daemonset fluent-bit -n amazon-cloudwatch --timeout 5m

--- a/tests/tasks/addons/fluentbit.yaml
+++ b/tests/tasks/addons/fluentbit.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: eks-addon-fluentbit
+  namespace: tekton-pipelines
+spec:
+  description: |
+    This task installs the FluentBit addon on an EKS cluster.
+  params:
+  - name: cluster-name
+    description: The name of the EKS cluster you want to add addons for.
+  - name: region
+    default: "us-west-2"
+    description: The region where the cluster is in.
+  - name: endpoint
+    default: ""
+  steps:
+  - name: create-fluentbit-addon
+    image: alpine/k8s:1.22.6
+    script: |
+      echo "Approving KCM requests"
+      kubectl certificate approve $(kubectl get csr | grep "Pending" | awk '{print $1}')  2>/dev/null || true
+      ENDPOINT_FLAG=""
+      if [ -n "$(params.endpoint)" ]; then
+        ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+      fi
+      aws eks $ENDPOINT_FLAG update-kubeconfig --name $(params.cluster-name) --region $(params.region)
+      #kubectl commands are purely for knowing state of cluster before kicking off the test.
+      kubectl version
+      kubectl config current-context
+      #install fluent bit addon
+      kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
+      cat > "./fluentbit-configmap.yaml" <<EOL
+      # create configmap for fluentbit config
+      apiVersion: v1
+      data:
+        cluster.name: $(params.cluster-name)
+        http.server: 'On'
+        http.port: '2020'
+        read.head: 'Off'
+        read.tail: 'On'
+        logs.region: $(params.region)
+      kind: ConfigMap
+      metadata:
+        name: fluent-bit-cluster-info
+        namespace: amazon-cloudwatch
+      EOL
+      kubectl apply -f ./fluentbit-configmap.yaml
+      kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+      sleep 30
+      kubectl get pods -n amazon-cloudwatch


### PR DESCRIPTION
The fluentbit addon can be used to send dataplane (including kubelet and kube-proxy) logs and application logs to CLoudWatch.