### PR TITLE
Cache IAM policies in infra 

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -102,6 +102,15 @@ cdk deploy KITInfrastructure --no-rollback \
   -c FluxAddonPaths="./test/infrastructure/clusters/addons/perfdash"
 ```
 
+### Dependent IAM policies:
+
+The application is caching IAM policies of two components as static files in `lib/addons/cached/`:
+* aws-load-balancer-controller
+* aws-ebs-csi-driver
+
+These IAM policies are pinned to a version and downloaded form Github. When the version of these components change
+in an upgrade, the cache needs to be updated by modifying the version values in `cache-iam-policies.sh` and executing file.
+
 ### Context Parameters:
 
 | Context Param       | Description                                                                                | Default                                                 |   |   |

--- a/infrastructure/cache-iam-policies.sh
+++ b/infrastructure/cache-iam-policies.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Downloads and saves cached versions of IAM policies for aws-load-balancer-controller and aws-ebs-csi-driver
+# This file must be executed to update the cache when these two dependencies are upgraded
+
+CACHE_DIR="./lib/addons/cached"
+
+LOAD_BALANCER_CONTROLLER_VERSION="v2.4.2"
+LOAD_BALANCER_CACHED_FILE="${CACHE_DIR}/aws-load-balancer-controller-iam-policy-${LOAD_BALANCER_CONTROLLER_VERSION}.json"
+LOAD_BALANCER_CACHED_URL="https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/${LOAD_BALANCER_CONTROLLER_VERSION}/docs/install/iam_policy.json"
+
+EBS_CSI_DRIVER_VERSION="v1.9.0"
+EBS_CSI_DRIVER_FILE="${CACHE_DIR}/aws-ebs-csi-driver-iam-policy-${EBS_CSI_DRIVER_VERSION}.json"
+EBS_CSI_DRIVER_URL="https://raw.githubusercontent.com/kubernetes-sigs/aws-ebs-csi-driver/${EBS_CSI_DRIVER_VERSION}/docs/example-iam-policy.json"
+
+curl -o "${LOAD_BALANCER_CACHED_FILE}" "${LOAD_BALANCER_CACHED_URL}"
+curl -o "${EBS_CSI_DRIVER_FILE}" "${EBS_CSI_DRIVER_URL}"

--- a/infrastructure/lib/addons/cached/aws-ebs-csi-driver-iam-policy-v1.9.0.json
+++ b/infrastructure/lib/addons/cached/aws-ebs-csi-driver-iam-policy-v1.9.0.json
@@ -1,0 +1,145 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateSnapshot",
+        "ec2:AttachVolume",
+        "ec2:DetachVolume",
+        "ec2:ModifyVolume",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeSnapshots",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumesModifications"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:CreateAction": [
+            "CreateVolume",
+            "CreateSnapshot"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteTags"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:snapshot/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/kubernetes.io/cluster/*": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteVolume"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/kubernetes.io/cluster/*": "owned"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/CSIVolumeSnapshotName": "*"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DeleteSnapshot"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "ec2:ResourceTag/ebs.csi.aws.com/cluster": "true"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/lib/addons/cached/aws-load-balancer-controller-iam-policy-v2.4.2.json
+++ b/infrastructure/lib/addons/cached/aws-load-balancer-controller-iam-policy-v2.4.2.json
@@ -1,0 +1,219 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "StringEquals": {
+                    "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeAccountAttributes",
+                "ec2:DescribeAddresses",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeInternetGateways",
+                "ec2:DescribeVpcs",
+                "ec2:DescribeVpcPeeringConnections",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups",
+                "ec2:DescribeInstances",
+                "ec2:DescribeNetworkInterfaces",
+                "ec2:DescribeTags",
+                "ec2:GetCoipPoolUsage",
+                "ec2:DescribeCoipPools",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeListeners",
+                "elasticloadbalancing:DescribeListenerCertificates",
+                "elasticloadbalancing:DescribeSSLPolicies",
+                "elasticloadbalancing:DescribeRules",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeTargetGroupAttributes",
+                "elasticloadbalancing:DescribeTargetHealth",
+                "elasticloadbalancing:DescribeTags"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "cognito-idp:DescribeUserPoolClient",
+                "acm:ListCertificates",
+                "acm:DescribeCertificate",
+                "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
+                "waf-regional:GetWebACL",
+                "waf-regional:GetWebACLForResource",
+                "waf-regional:AssociateWebACL",
+                "waf-regional:DisassociateWebACL",
+                "wafv2:GetWebACL",
+                "wafv2:GetWebACLForResource",
+                "wafv2:AssociateWebACL",
+                "wafv2:DisassociateWebACL",
+                "shield:GetSubscriptionState",
+                "shield:DescribeProtection",
+                "shield:CreateProtection",
+                "shield:DeleteProtection"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateSecurityGroup"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "StringEquals": {
+                    "ec2:CreateAction": "CreateSecurityGroup"
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:CreateTags",
+                "ec2:DeleteTags"
+            ],
+            "Resource": "arn:aws:ec2:*:*:security-group/*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:RevokeSecurityGroupIngress",
+                "ec2:DeleteSecurityGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:CreateTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:CreateListener",
+                "elasticloadbalancing:DeleteListener",
+                "elasticloadbalancing:CreateRule",
+                "elasticloadbalancing:DeleteRule"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags",
+                "elasticloadbalancing:RemoveTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:listener/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener/app/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/net/*/*/*",
+                "arn:aws:elasticloadbalancing:*:*:listener-rule/app/*/*/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:SetIpAddressType",
+                "elasticloadbalancing:SetSecurityGroups",
+                "elasticloadbalancing:SetSubnets",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ModifyTargetGroup",
+                "elasticloadbalancing:ModifyTargetGroupAttributes",
+                "elasticloadbalancing:DeleteTargetGroup"
+            ],
+            "Resource": "*",
+            "Condition": {
+                "Null": {
+                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:RegisterTargets",
+                "elasticloadbalancing:DeregisterTargets"
+            ],
+            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:SetWebAcl",
+                "elasticloadbalancing:ModifyListener",
+                "elasticloadbalancing:AddListenerCertificates",
+                "elasticloadbalancing:RemoveListenerCertificates",
+                "elasticloadbalancing:ModifyRule"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -28,6 +28,9 @@ export class KITInfrastructure extends Stack {
     const testSA = this.node.tryGetContext("TestServiceAccount")
     const testNS = this.node.tryGetContext("TestNamespace")
 
+    // If set to false it will attempt to download policies from Github
+    const useCachedIAMPolicy = this.getContextOrDefault("UseCachedIAMPolicy","false") == "true"
+
     // A VPC, including NAT GWs, IGWs, where we will run our cluster
     const vpc = new ec2.Vpc(this, 'VPC', {});
 
@@ -175,8 +178,9 @@ export class KITInfrastructure extends Stack {
       new AWSEBSCSIDriver(this, 'AWSEBSCSIDriver', {
         cluster: cluster,
         namespace: 'aws-ebs-csi-driver',
-        version: 'v1.9.0',
+        version: 'v1.9.0', // When updating this ensure to also update and run cache-iam-policies.sh
         chartVersion: 'v2.8.1',
+        useCachedIAMPolicy: useCachedIAMPolicy,
       }).node.addDependency(cluster);
     }
 
@@ -202,7 +206,8 @@ export class KITInfrastructure extends Stack {
     new AWSLoadBalancerController(this, 'AWSLoadBalancerController', {
       cluster: cluster,
       namespace: 'aws-load-balancer-controller',
-      version: 'v2.4.2',
+      version: 'v2.4.2', // When updating this ensure to also update and run cache-iam-policies.sh
+      useCachedIAMPolicy: useCachedIAMPolicy,
     }).node.addDependency(cluster);
 
     if(installKitAddon == "true"){

--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -28,9 +28,6 @@ export class KITInfrastructure extends Stack {
     const testSA = this.node.tryGetContext("TestServiceAccount")
     const testNS = this.node.tryGetContext("TestNamespace")
 
-    // If set to false it will attempt to download policies from Github
-    const useCachedIAMPolicy = this.getContextOrDefault("UseCachedIAMPolicy","false") == "true"
-
     // A VPC, including NAT GWs, IGWs, where we will run our cluster
     const vpc = new ec2.Vpc(this, 'VPC', {});
 
@@ -180,7 +177,6 @@ export class KITInfrastructure extends Stack {
         namespace: 'aws-ebs-csi-driver',
         version: 'v1.9.0', // When updating this ensure to also update and run cache-iam-policies.sh
         chartVersion: 'v2.8.1',
-        useCachedIAMPolicy: useCachedIAMPolicy,
       }).node.addDependency(cluster);
     }
 
@@ -207,7 +203,6 @@ export class KITInfrastructure extends Stack {
       cluster: cluster,
       namespace: 'aws-load-balancer-controller',
       version: 'v2.4.2', // When updating this ensure to also update and run cache-iam-policies.sh
-      useCachedIAMPolicy: useCachedIAMPolicy,
     }).node.addDependency(cluster);
 
     if(installKitAddon == "true"){


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This will cache the IAM policies in the repo instead of downloading it every time. Helps with running the library in environment with no Internet access during CDK setup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
