### PR TITLE
Added Cloudwatch Role to Kit-infrastructure

### DIFF
--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -142,7 +142,8 @@ export class KITInfrastructure extends Stack {
                     "s3:*",
                     "sqs:*",
                     "fis:*",
-                    "events:*"
+                    "events:*",
+                    "cloudwatch:*"  
                 ],
             }),
         ],


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adding Cloud watch policies  permissions to kit-infrastructure to fix after issue happened in these two commits https://github.com/awslabs/kubernetes-iteration-toolkit/pull/319 and https://github.com/awslabs/kubernetes-iteration-toolkit/pull/316

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
