### PR TITLE
grant AmazonPrometheusRemoteWriteAccess in kit operator

### DIFF
--- a/operator/pkg/awsprovider/iam/reconciler.go
+++ b/operator/pkg/awsprovider/iam/reconciler.go
@@ -45,6 +45,7 @@ var (
 		"arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore",
 		"arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy",
 		"arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly",
+		"arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess",
 	}
 )
 


### PR DESCRIPTION
The kit guest cluster can't do remote write w/o this permission.
Attach AmazonPrometheusRemoteWriteAccess policy. The prometheus server can't do remote write w/o this change.