### PR TITLE
Change etcd image tag back

### DIFF
--- a/operator/pkg/controllers/etcd/pod.go
+++ b/operator/pkg/controllers/etcd/pod.go
@@ -80,7 +80,7 @@ func podSpecFor(controlPlane *v1alpha1.ControlPlane) *v1.PodSpec {
 				MountPath: "/etc/kubernetes/",
 			}},
 			Command: []string{
-				"./etc/kubernetes/bootstrap.sh",
+				"/etc/kubernetes/bootstrap.sh",
 			},
 			Args: []string{
 				"--cert-file=/etc/kubernetes/pki/etcd/server/server.crt",

--- a/operator/pkg/utils/imageprovider/imageprovider.go
+++ b/operator/pkg/utils/imageprovider/imageprovider.go
@@ -57,7 +57,7 @@ func KubeProxy(version string) string {
 }
 
 func ETCD() string {
-	return repositoryName + "etcd-io/etcd:v3.5.4-eks-1-23-9"
+	return repositoryName + "etcd-io/etcd:v3.4.16-eks-1-21-4"
 }
 
 func CoreDNS() string {


### PR DESCRIPTION
Change etcd image to what it used to be due to lack of sh in the base image.
Use absolute path for bootstrap script.

Even though https://github.com/awslabs/kubernetes-iteration-toolkit/pull/328 has `[DO-NOT-MERGE]` in the title, it was merged before it's ready to be merged.

The new etcd images appear to be built with distroless or similar base image that doesn't have `sh`, while our [etcd bootstrap script](https://github.com/awslabs/kubernetes-iteration-toolkit/blob/81e33bd66a76ef43028b72b3692f686e3c1e0288/operator/pkg/controllers/etcd/bootstrapconfig.go#L61-L94) relies on it.

We can't upgrade etcd to newer image tag until we figure out how are we going to deal with the etcd bootstrap script.

This PR also changes the bootstrap script to use the absolute path instead of the relative path. 