### PR TITLE
Fix broken links for cfn templates

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -16,9 +16,9 @@ spec:
   - name: slack-message
   - name: amp-workspace-id
   - name: service-role-cfn-url
-    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/role/tests/assets/eks_service_role.json"
+    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_service_role.json"
   - name: node-role-cfn-url
-    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/role/tests/assets/eks_node_role.json"
+    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_node_role.json"
   tasks:
   - name: slack-notification
     params:

--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -22,9 +22,9 @@ spec:
     default: "1.23"
   - name: amp-workspace-id
   - name: service-role-cfn-url
-    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/role/tests/assets/eks_service_role.json"
+    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_service_role.json"
   - name: node-role-cfn-url
-    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/role/tests/assets/eks_node_role.json"
+    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_node_role.json"
   tasks:
   - name: slack-notification
     params:


### PR DESCRIPTION
This commit fixes broken links for cfn templates.

Signed-off-by: Ashish Ranjan <rnshis@amazon.com>