### PR TITLE
Fix incorrect name for nodegroup create task

### DIFF
--- a/tests/tasks/setup/eks/awscli-mng.yaml
+++ b/tests/tasks/setup/eks/awscli-mng.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: awscli-eks-nodegroup
+  name: awscli-eks-nodegroup-create
   namespace: tekton-pipelines
 spec:
   description: |


### PR DESCRIPTION
This commit fixes incorrect name for nodegroup task.

Signed-off-by: Ashish Ranjan <rnshis@amazon.com>