### PR TITLE
Adding 1.24 support for kit operator

### DIFF
--- a/operator/pkg/utils/imageprovider/imageprovider.go
+++ b/operator/pkg/utils/imageprovider/imageprovider.go
@@ -21,6 +21,7 @@ var (
 		"1.21": kubeVersion121Tag,
 		"1.22": kubeVersion122Tag,
 		"1.23": kubeVersion123Tag,
+		"1.24": kubeVersion124Tag,
 	}
 )
 
@@ -36,6 +37,7 @@ const (
 	kubeVersion121Tag = "v1.21.14-eks-1-21-21"
 	kubeVersion122Tag = "v1.22.16-eks-1-22-14"
 	kubeVersion123Tag = "v1.23.13-eks-1-23-9"
+	kubeVersion124Tag = "v1.24.8-eks-1-24-5"
 	repositoryName    = "public.ecr.aws/eks-distro/"
 	busyBoxImage      = "public.ecr.aws/docker/library/busybox:stable"
 )


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updated the kube version tags with 1.24 and able to spin up the nodes with 1.24 version and also checked the Events for kube-apiserver in Cp side 
```k describe pod example-apiserver-59dcd56cc4-7ps6f```
```Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  14m   default-scheduler  Successfully assigned default/example-apiserver-59dcd56cc4-7ps6f to ip-10-2-115-191.us-west-2.compute.internal
  Normal   Pulling    14m   kubelet            Pulling image "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.8-eks-1-24-5"
  Normal   Pulled     14m   kubelet            Successfully pulled image "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.8-eks-1-24-5" in 2.722247257s
  Normal   Created    14m   kubelet            Created container apiserver
  Normal   Started    14m   kubelet            Started container apiserver
  Warning  Unhealthy  14m   kubelet            Readiness probe failed: HTTP probe failed with statuscode: 403

```

```
k get pods
NAME                                     READY   STATUS    RESTARTS   AGE
example-apiserver-59dcd56cc4-7ps6f       1/1     Running   0          18m
example-authenticator-wx5dl              1/1     Running   0          32m
example-controller-manager-w8n4g         1/1     Running   0          18m
example-etcd-0                           1/1     Running   0          31m
example-etcd-1                           1/1     Running   0          32m
example-etcd-2                           1/1     Running   0          32m
example-scheduler-zmhsm                  1/1     Running   0          18m
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
