### PR TITLE
Feature to delete cluster resources when TTL expires

### DIFF
--- a/operator/charts/kit-operator/crds/control-plane-crd.yaml
+++ b/operator/charts/kit-operator/crds/control-plane-crd.yaml
@@ -9634,6 +9634,8 @@ spec:
                           type: object
                       type: object
                   type: object
+                ttl:
+                  type: string
               type: object
             status:
               properties:

--- a/operator/pkg/apis/controlplane/v1alpha1/controlplane.go
+++ b/operator/pkg/apis/controlplane/v1alpha1/controlplane.go
@@ -46,10 +46,12 @@ type ControlPlaneList struct {
 // master and etcd are configured to run. By default, KIT uses all the default
 // values and ControlPlaneSpec can be empty.
 type ControlPlaneSpec struct {
-	KubernetesVersion         string     `json:"kubernetesVersion,omitempty"`
-	ColocateAPIServerWithEtcd bool       `json:"colocateAPIServerWithEtcd,omitempty"`
-	Master                    MasterSpec `json:"master,omitempty"`
-	Etcd                      Etcd       `json:"etcd,omitempty"`
+	KubernetesVersion         string `json:"kubernetesVersion,omitempty"`
+	ColocateAPIServerWithEtcd bool   `json:"colocateAPIServerWithEtcd,omitempty"`
+	// TTL is the duration for which control plane resources are active, once expired resource will be automatically deleted by the operator
+	TTL    string     `json:"ttl,omitempty"`
+	Master MasterSpec `json:"master,omitempty"`
+	Etcd   Etcd       `json:"etcd,omitempty"`
 }
 
 type Etcd struct {

--- a/operator/pkg/controllers/controlplane/controlplane.go
+++ b/operator/pkg/controllers/controlplane/controlplane.go
@@ -17,7 +17,6 @@ package controlplane
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/apis/controlplane"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/apis/controlplane/v1alpha1"
@@ -28,7 +27,6 @@ import (
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/controllers/master"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/kubeprovider"
 	"github.com/awslabs/kubernetes-iteration-toolkit/operator/pkg/results"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -60,29 +58,12 @@ func (c *controlPlane) For() controllers.Object {
 
 // Reconcile will reconcile all the components running on the control plane
 func (c *controlPlane) Reconcile(ctx context.Context, object controllers.Object) (res *reconcile.Result, err error) {
-	cp, ok := object.(*v1alpha1.ControlPlane)
-	if !ok {
-		return nil, fmt.Errorf("parsing control plane object")
-	}
-	// if the cluster CP TTL has expired set deletion timestamp for the object
-	if cp.Spec.TTL != "" {
-		duration, err := time.ParseDuration(cp.Spec.TTL)
-		if err != nil {
-			return nil, fmt.Errorf("parsing TTL duration, %w", err)
-		}
-		deleteAfter := object.GetCreationTimestamp().Add(duration)
-		if time.Now().After(deleteAfter) {
-			t := metav1.Now()
-			object.SetDeletionTimestamp(&t)
-			return &reconcile.Result{Requeue: true}, nil
-		}
-	}
 	for _, resource := range []controlplane.Controller{
 		c.etcdController,
 		c.masterController,
 		c.addonsController,
 	} {
-		if err := resource.Reconcile(ctx, cp); err != nil {
+		if err := resource.Reconcile(ctx, object.(*v1alpha1.ControlPlane)); err != nil {
 			return nil, fmt.Errorf("control plane reconciling, %w", err)
 		}
 	}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
When a TTL is set for a CP object, operator will clean up the resources. This is to avoid leaking CP objects in CI when CP objects are not being deleted and they tend to run for too long.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
