### PR TITLE
Allow session tokens to be forwarded from Management Cluster to Guest Cluster

### DIFF
--- a/operator/pkg/awsprovider/launchtemplate/reconciler.go
+++ b/operator/pkg/awsprovider/launchtemplate/reconciler.go
@@ -150,7 +150,8 @@ func (c *Controller) createLaunchTemplate(ctx context.Context, dataplane *v1alph
 				Name: aws.String(instanceProfile),
 			},
 			MetadataOptions: &ec2.LaunchTemplateInstanceMetadataOptionsRequest{
-				HttpTokens: aws.String(ec2.LaunchTemplateHttpTokensStateRequired),
+				HttpTokens:              aws.String(ec2.LaunchTemplateHttpTokensStateRequired),
+				HttpPutResponseHopLimit: aws.Int64(2),
 			},
 			Monitoring:       &ec2.LaunchTemplatesMonitoringRequest{Enabled: ptr.Bool(true)},
 			SecurityGroupIds: []*string{ptr.String(securityGroupID)},


### PR DESCRIPTION
This addresses an issue where guest clusters were not able to create `PVs` due to a misconfigured `IMDS` component in the launch template for guest cluster ASGs.

Example error from `ebs-csi-controller` pod below:
```
I0217 21:45:26.883340       1 event.go:285] Event(v1.ObjectReference{Kind:"PersistentVolumeClaim", Namespace:"monitoring", Name:"prometheus-k8s-db-prometheus-k8s-0", UID:"d142625b-7774-46cc-b58c-80bfa93fb8b2", APIVersion:"v1", ResourceVersion:"2984", FieldPath:""}): type: 'Warning' reason: 'ProvisioningFailed' failed to provision volume with StorageClass "kit-io1": rpc error: code = Internal desc = Could not create volume "pvc-d142625b-7774-46cc-b58c-80bfa93fb8b2": could not create volume in EC2: NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
SharedCredsLoad: failed to load profile, .
EC2RoleRequestError: no EC2 instance role found
caused by: EC2MetadataError: failed to make EC2Metadata request

	status code: 401, request id:
```

This change allows the token to be forwarded to the guest cluster from the management cluster without expiring.

This was tested by running a tekton pipeline that stands up a prometheus stack in a guest cluster:

```
I0220 20:15:39.101416      36 prometheus.go:439] Waiting for Prometheus stack to become healthy...
I0220 20:16:09.125740      36 util.go:101] 4/6 targets are ready, example not ready target: {map[container:prometheus endpoint:web instance:10.0.69.52:9090 job:prometheus-k8s namespace:monitoring pod:prometheus-k8s-0 service:prometheus-k8s] unknown}
I0220 20:16:39.116891      36 util.go:104] All 6 expected targets are ready
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
