### PR TITLE
Fix aws-load-balancer-controller addon

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -99,7 +99,7 @@ cdk deploy KITInfrastructure --no-rollback \
   -c AWSEBSCSIDriverAddon=false \
   -c KarpenterAddon=false \
   -c KITAddon=false \
-  -c FluxAddonPaths="./test/infrastructure/clusters/addons/perfdash"
+  -c FluxRepoAddonPaths="./infrastructure/k8s-config/clusters/addons/"
 ```
 
 ### Dependent IAM policies:
@@ -139,7 +139,7 @@ Follow the steps from here: https://github.com/awslabs/kubernetes-iteration-tool
 | FluxRepoURL         | Flux Source git repo URL to synchronize KIT infrastructure like Tekton                     | https://github.com/awslabs/kubernetes-iteration-toolkit |   |   |
 | FluxRepoBranch      | Flux Source git repo branch to synchronize KIT infrastructure                              | main                                                    |   |   |
 | FluxRepoPath        | Flux Source git repo path to Kubernetes resources                                          | ./infrastructure/k8s-config/clusters/kit-infrastructure |   |   |
-| FluxAddonPaths      | Flux Source git repo paths (separted by comma) to Kubernetes addons.                       |                                                         |   |   |
+| FluxRepoAddonPaths      | Flux Source git repo paths (separted by comma) to Kubernetes addons.                       |                                                         |   |   |
 | TestFluxRepoName    | Flux Source git repo name to synchronize application tests like Tekton Tasks and Pipelines |                                                         |   |   |
 | TestFluxRepoURL     | Flux Source git repo URL to synchronize application tests                                  |                                                         |   |   |
 | TestFluxRepoBranch  | Flux Source git repo branch to synchronize application tests                               |                                                         |   |   |

--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -88,6 +88,7 @@ export class KITInfrastructure extends Stack {
         metadataOptions: {
           httpEndpoint: "enabled",
           httpTokens: "required",
+          httpPutResponseHopLimit: 2,
         }
       }
     })


### PR DESCRIPTION
Issue #, if available:
Fix Aws-load-balancer-controller  was broken since this change - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/363

because the controller expects the hop_limit config to be set as part of this PR change https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/2243/files

Also, fix readme instructions for flux-addons-installation as this was affecting perf-dash installation from this PR - https://github.com/awslabs/kubernetes-iteration-toolkit/pull/306/files


Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
