### PR TITLE
allow ability to run tests for different k8s versions

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -16,6 +16,7 @@ spec:
   - name: slack-message
   - name: amp-workspace-id
   - name: vpc-cfn-url
+  - name: kubernetes-version
   - name: service-role-cfn-url
     default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_service_role.json"
   - name: node-role-cfn-url
@@ -75,6 +76,8 @@ spec:
       value: $(params.endpoint)
     - name: vpc-stack-name
       value: $(params.cluster-name)
+    - name: kubernetes-version
+      value: $(params.kubernetes-version)    
     runAfter:
     - create-cluster-node-role
     - create-cluster-service-role


### PR DESCRIPTION
Issue #, if available:
This gives ability to run loadtests for various eks versions through our pipelines. Changes to triggers def are applied in internal repo.


Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
