### PR TITLE
Tekton pipelinerun and taskrun cleaner

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -19,6 +19,7 @@ spec:
     # include releases
     !/pipeline/previous/v0.33.2/release.yaml
     !/triggers/previous/v0.19.0/release.yaml
+    !/triggers/previous/v0.19.1/intercetors.yaml
     !/dashboard/previous/v0.24.1/tekton-dashboard-release.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
@@ -119,6 +120,36 @@ spec:
         kind: Deployment
         metadata:
           name: tekton-triggers-webhook
+          namespace: tekton-pipelines
+        spec:
+          template:
+            spec:
+              tolerations:
+                - key: CriticalAddonsOnly
+                  operator: Exists
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: tekton-interceptors
+  namespace: tekton-pipelines
+spec:
+  interval: 2m0s
+  path: ./triggers/previous/v0.19.1
+  prune: true
+  sourceRef:
+    kind: Bucket
+    name: tekton
+  patches:
+    - target:
+        kind: Deployment
+        name: tekton-triggers-core-interceptors
+        namespace: tekton-pipelines
+      patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: tekton-triggers-core-interceptors
           namespace: tekton-pipelines
         spec:
           template:

--- a/tests/pipelines/cleanup/README.md
+++ b/tests/pipelines/cleanup/README.md
@@ -1,0 +1,24 @@
+# Cleanup old TaskRuns and PipelineRuns
+
+Here is how users can clean up old TaskRuns and PipelineRuns.
+
+The general method is to use a CronJob to trigger a Task that deletes all but the `n` most recent PipelineRuns and `2*n` most recent TaskRuns.
+
+## Prerequisites
+
+* A Kubernetes cluster with Tekton Pipelines installed
+* Several old TaskRuns and/or PipelineRuns you wish to delete
+
+## Scheduling the cleanup job
+
+You'll need to install all the files in this directory to run the cleanup task.
+
+* [serviceaccount.yaml](serviceaccount.yaml): this creates the service account needed to run the job, along with the associated ClusterRole and Rolebinding.
+
+* [cleanup-template.yaml](cleanup-template.yaml): this creates the TriggerTemplate that spawns the TaskRun that does the deleting. It uses the `tkn` CLI to do the deleting. 
+
+* [binding.yaml](binding.yaml): this creates the TriggerBinding that is used to pass parameters to the TaskRun.
+
+* [eventlistener.yaml](eventlistener.yaml): this creates the sink that receives the incoming event that triggers the creation of the cleanup job.
+
+* [cronjob.yaml](cronjob.yaml): this is used to run the cleanup job on a schedule. There are two environmental variables that need to be set in the job: `NAMESPACE` for the namespace you wish to clean up, and `CLEANUP_KEEP` for the number of PipelineRuns to keep. The schedule for the job running can be set in the `.spec.schedule` field using [crontab format](https://crontab.guru/)

--- a/tests/pipelines/cleanup/binding.yaml
+++ b/tests/pipelines/cleanup/binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerBinding
+metadata:
+  name: cleanup-details
+  namespace: tekton-pipelines 
+spec:
+  params:
+  - name: keep
+    value: $(body.params.cleanup.keep) 
+  - name: namespace
+    value: $(body.params.target.namespace)

--- a/tests/pipelines/cleanup/cleanup-template.yaml
+++ b/tests/pipelines/cleanup/cleanup-template.yaml
@@ -1,0 +1,44 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cleanup-runs
+  namespace: tekton-pipelines 
+spec:
+  params:
+  - name: namespace
+    description: Namespace to cleanup to in the target cluster
+  - name: clusterResource
+    description: Name of the cluster resource that points to the target cluster
+  - name: keep
+    description: Amount of old resources to keep
+    default: "200"
+  resourcetemplates:
+  - apiVersion: tekton.dev/v1beta1
+    kind: TaskRun
+    metadata:
+      name: cleanupruns-$(uid)
+    spec:
+      serviceAccountName: tekton-cleaner
+      taskSpec:
+        params:
+        - name: keep
+        - name: namespace
+        steps:
+        - name: cleanup-pr-tr
+          image: gcr.io/tekton-releases/dogfooding/tkn
+          script: |
+            #!/bin/sh
+            set -ex
+            # A safety check, to avoid deleting too much!
+            if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
+              echo "This task cannot be used to delete *all* resources from a cluster" >&2
+              echo "Please specifcy a value for keep > 0"
+              exit 1
+            fi
+            # Cleanup pipelineruns first, as this will delete tasksruns too
+            tkn pr delete -n $(params.namespace) --keep $(params.keep)
+      params:
+      - name: keep
+        value: $(tt.params.keep)
+      - name: namespace
+        value: $(tt.params.namespace)

--- a/tests/pipelines/cleanup/cronjob.yaml
+++ b/tests/pipelines/cleanup/cronjob.yaml
@@ -1,0 +1,47 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: cleanup-trigger
+  namespace: tekton-pipelines 
+spec:
+  schedule: "0 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+          - name: workspace
+            emptyDir: {}
+          containers:
+          - name: trigger
+            image: curlimages/curl
+            command:
+              - /bin/sh
+            args:
+              - -ce
+              - |
+                cat <<EOF > /workspace/post-body.json
+                {
+                  "trigger-template": "cleanup",
+                  "params": {
+                    "target": {
+                      "namespace": "$NAMESPACE"
+                    },
+                    "cleanup": {
+                        "keep": "$CLEANUP_KEEP"
+                    }
+                  }
+                }
+                EOF
+                curl -d @/workspace/post-body.json $SINK_URL
+            volumeMounts:
+            - mountPath: /workspace
+              name: workspace
+            env:
+              - name: SINK_URL
+                value: "http://el-tekton-cd.tekton-pipelines.svc.cluster.local:8080"
+              - name: NAMESPACE
+                value: "tekton-pipelines"
+              - name: CLEANUP_KEEP
+                value: "50"
+          restartPolicy: Never

--- a/tests/pipelines/cleanup/eventlistener.yaml
+++ b/tests/pipelines/cleanup/eventlistener.yaml
@@ -1,0 +1,20 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: EventListener
+metadata:
+  name: tekton-cd
+  namespace: tekton-pipelines
+spec:
+  serviceAccountName: tekton-cleaner
+  triggers:
+    - name: cleanup
+      interceptors:
+        - ref:
+            name: "cel"
+          params:
+            - name: "filter"
+              value: |
+                'trigger-template' in body && body['trigger-template'] == 'cleanup'
+      bindings:
+        - ref: cleanup-details
+      template:
+        ref: cleanup-runs

--- a/tests/pipelines/cleanup/serviceaccount.yaml
+++ b/tests/pipelines/cleanup/serviceaccount.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tekton-cleaner
+  namespace: tekton-pipelines 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-cleaner-roles
+rules:
+- apiGroups: [""]
+  resources: ["namespaces", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["tekton.dev"]
+  resources: ["pipelineruns", "taskruns", "pipelineresources"]
+  verbs: ["get", "list", "delete", "create"]
+- apiGroups: ["triggers.tekton.dev"]
+  resources: ["eventlisteners", "triggerbindings", "triggertemplates", "interceptors"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-cleaner-clusterroles
+rules:
+  - apiGroups: ["triggers.tekton.dev"]
+    resources: ["clustertriggerbindings", "clusterinterceptors"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tektoncd-cleaner-delete-pr-tr-rolebinding
+  namespace: tekton-pipelines
+subjects:
+- kind: ServiceAccount
+  name: tekton-cleaner
+  namespace: tekton-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tekton-cleaner-roles


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- This PR provides an opinionated way to automatically manage cleaning up of tekton pipelineruns and taskruns on host cluster.
- Also install clusterinterceptors which goes with it

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
