### PR TITLE
increase default cpu/mem for karpenter provsioned instances

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/kit-provisioner.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/kit-provisioner.yaml
@@ -26,6 +26,9 @@ spec:
       - amd64
   - key: kit.k8s.sh/app
     operator: Exists
+  - key: "karpenter.k8s.aws/instance-cpu"
+    operator: In
+    values: ["16", "32", "48", "64"]
   - key: kit.k8s.sh/control-plane-name
     operator: Exists
   limits: 

--- a/infrastructure/k8s-config/clusters/kit-infrastructure/provisioner.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/provisioner.yaml
@@ -29,6 +29,9 @@ spec:
     operator: In
     values:
       - amd64
+  - key: "karpenter.k8s.aws/instance-cpu"
+    operator: In
+    values: ["16", "32", "48", "64"]
   limits: 
     resources: 
       cpu: 8000


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Increase the defaults for karpenter provisioned instances to avoid OOMs and make sure pods have enough CPUs to run workload.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
