### PR TITLE
Fix kitctl-test workflow name

### DIFF
--- a/.github/workflows/kitctl-test.yml
+++ b/.github/workflows/kitctl-test.yml
@@ -1,4 +1,4 @@
-name: This workflow automates the build, testing, and bootstrapping of a test environment on Kubernetes using KIT CLI
+name: kit-e2e-test
 on:
   push:
     branches: [main]
@@ -192,7 +192,6 @@ jobs:
             if [ $status -eq 0 ]; then
               echo "Command executed successfully for $i iteration."
               COMMAND_COMPLETED=true
-              break
             elif [ $status -eq 124 ]; then
               echo "Command timed out. Retrying in $RETRY_DELAY seconds."
             elif [ $status -eq 143 ]; then


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Made changes for workflow run name  with kit-e2e-test : https://github.com/awslabs/kubernetes-iteration-toolkit/pull/365#discussion_r1184380428

This pull request modifies the `kitctl` deletion command behavior. Previously, the loop would break when the command execution was successful, indicated by an exit status of 0. With this update, the loop will continue to run the command, even if it was successful in the previous iteration as sporadically resources are getting leaked.

This change allows the workflow to keep running the `kitctl` command despite successful completions, as long as the elapsed time doesn't exceed the specified maximum duration.