### PR TITLE
Update k8s version

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -17,9 +17,9 @@ spec:
     # exclude all
     /*
     # include releases
-    !/pipeline/previous/v0.33.2/release.yaml
-    !/triggers/previous/v0.19.0/release.yaml
-    !/triggers/previous/v0.19.1/intercetors.yaml
+    !/pipeline/previous/v0.47.0/release.yaml
+    !/triggers/previous/v0.23.1/release.yaml
+    !/triggers/previous/v0.23.1/intercetors.yaml
     !/dashboard/previous/v0.24.1/tekton-dashboard-release.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
@@ -29,7 +29,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./pipeline/previous/v0.33.2
+  path: ./pipeline/previous/v0.47.0
   prune: true
   sourceRef:
     kind: Bucket
@@ -89,7 +89,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./triggers/previous/v0.19.0
+  path: ./triggers/previous/v0.23.1
   prune: true
   sourceRef:
     kind: Bucket
@@ -135,7 +135,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./triggers/previous/v0.19.1
+  path: ./triggers/previous/v0.23.1
   prune: true
   sourceRef:
     kind: Bucket

--- a/infrastructure/lib/addons/karpenter.ts
+++ b/infrastructure/lib/addons/karpenter.ts
@@ -24,34 +24,37 @@ export class Karpenter extends Construct {
             namespace: props.namespace
         })
         sa.node.addDependency(ns)
-        sa.role.attachInlinePolicy(new iam.Policy(this, 'karpenter-controller-policy', {
+        const karpenterControllerPolicy = new iam.PolicyDocument({
             statements: [
-                new iam.PolicyStatement({
-                    resources: ['*'],
-                    actions: [
-                        // Write Operations
-                        "ec2:CreateLaunchTemplate",
-                        "ec2:CreateFleet",
-                        "ec2:RunInstances",
-                        "ec2:CreateTags",
-                        "iam:PassRole",
-                        "ec2:TerminateInstances",
-                        "ec2:DeleteLaunchTemplate",
-                        // Read Operations
-                        "ec2:DescribeAvailabilityZones",
-                        "ec2:DescribeImages",
-                        "ec2:DescribeInstances",
-                        "ec2:DescribeInstanceTypeOfferings",
-                        "ec2:DescribeInstanceTypes",
-                        "ec2:DescribeLaunchTemplates",
-                        "ec2:DescribeSecurityGroups",
-                        "ec2:DescribeSpotPriceHistory",
-                        "ec2:DescribeSubnets",
-                        "pricing:GetProducts",
-                        "ssm:GetParameter",
-                    ],
-                }),
+              new iam.PolicyStatement({
+                resources: ['*'],
+                actions: [
+                    // Write Operations
+                    "ec2:CreateLaunchTemplate",
+                    "ec2:CreateFleet",
+                    "ec2:RunInstances",
+                    "ec2:CreateTags",
+                    "iam:PassRole",
+                    "ec2:TerminateInstances",
+                    "ec2:DeleteLaunchTemplate",
+                    // Read Operations
+                    "ec2:DescribeAvailabilityZones",
+                    "ec2:DescribeImages",
+                    "ec2:DescribeInstances",
+                    "ec2:DescribeInstanceTypeOfferings",
+                    "ec2:DescribeInstanceTypes",
+                    "ec2:DescribeLaunchTemplates",
+                    "ec2:DescribeSecurityGroups",
+                    "ec2:DescribeSpotPriceHistory",
+                    "ec2:DescribeSubnets",
+                    "pricing:GetProducts",
+                    "ssm:GetParameter",
+                ],
+              }),
             ],
+          });
+        sa.role.attachInlinePolicy(new iam.Policy(this, 'karpenter-controller-policy', {
+            document: karpenterControllerPolicy,
         }));
 
         const nodeInstanceProfile = new iam.CfnInstanceProfile(this, 'karpenter-instance-profile', {

--- a/infrastructure/lib/kit-infrastructure.ts
+++ b/infrastructure/lib/kit-infrastructure.ts
@@ -45,7 +45,7 @@ export class KITInfrastructure extends Stack {
       clusterName: id,
       vpc: vpc,
       role: clusterRole,
-      version: eks.KubernetesVersion.V1_21,
+      version: eks.KubernetesVersion.V1_26,
       defaultCapacity: 0,
     });
 
@@ -68,6 +68,7 @@ export class KITInfrastructure extends Stack {
 
     const sg = new SecurityGroup(this, "NodeSecurityGroup", {
       description: "Worker Node Security Group",
+      allowAllIpv6Outbound: true,
       vpc: vpc,
     });
     cluster.clusterSecurityGroup.addIngressRule(sg, ec2.Port.allTraffic())

--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2",
       "dependencies": {
         "@types/js-yaml": "^4.0.5",
-        "aws-cdk-lib": "2.31.1",
+        "aws-cdk-lib": "2.77.0",
         "constructs": "^10.1.78",
         "js-yaml": "^4.1.0",
         "source-map-support": "^0.5.21",
@@ -29,6 +29,21 @@
         "ts-node": "^10.8.0",
         "typescript": "~4.7.4"
       }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.154",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.154.tgz",
+      "integrity": "sha512-sBL/l1gf7me3I5zSdpwKuDWJoimBngXgV9v/zHV4uEdek2iYbRAbZaO+Eti62dY7Pw2xU5ZUrPdXIMSOXyzy3Q=="
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.129",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.129.tgz",
+      "integrity": "sha512-CVoB2u0wI0cK2JyWWiKLIYBMF+RUG1o5mHidF/lXtVSzvHFYPxAFjZVz9XYg2tZSMaV6QVNijy4Z6ljp9/tRhg=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -1260,9 +1275,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.31.1.tgz",
-      "integrity": "sha512-1IFgMxr1PpX90KFzTRZKVwfY+qP/UzLsrNgfylvqveOKy3R6qtGAhAx186+Zy2nx+wYoy+hVz89CZSItGDapMA==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+      "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1272,17 +1287,22 @@
         "minimatch",
         "punycode",
         "semver",
+        "table",
         "yaml"
       ],
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1296,6 +1316,51 @@
       "version": "1.0.2",
       "inBundle": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ajv": {
+      "version": "8.12.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/astral-regex": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/aws-cdk-lib/node_modules/at-least-node": {
       "version": "1.0.0",
@@ -1327,8 +1392,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/color-convert": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -1352,12 +1443,25 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
@@ -1377,6 +1481,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1401,15 +1510,23 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/require-from-string": {
+      "version": "2.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.3.7",
+      "version": "7.3.8",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1422,12 +1539,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/table": {
+      "version": "6.8.1",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/uri-js": {
+      "version": "4.4.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
@@ -3407,7 +3587,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3821,7 +4000,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3958,7 +4136,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4781,8 +4958,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -4822,6 +4998,21 @@
     }
   },
   "dependencies": {
+    "@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.154",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.154.tgz",
+      "integrity": "sha512-sBL/l1gf7me3I5zSdpwKuDWJoimBngXgV9v/zHV4uEdek2iYbRAbZaO+Eti62dY7Pw2xU5ZUrPdXIMSOXyzy3Q=="
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
+    },
+    "@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.129",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.129.tgz",
+      "integrity": "sha512-CVoB2u0wI0cK2JyWWiKLIYBMF+RUG1o5mHidF/lXtVSzvHFYPxAFjZVz9XYg2tZSMaV6QVNijy4Z6ljp9/tRhg=="
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -5813,23 +6004,52 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-cdk-lib": {
-      "version": "2.31.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.31.1.tgz",
-      "integrity": "sha512-1IFgMxr1PpX90KFzTRZKVwfY+qP/UzLsrNgfylvqveOKy3R6qtGAhAx186+Zy2nx+wYoy+hVz89CZSItGDapMA==",
+      "version": "2.77.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.77.0.tgz",
+      "integrity": "sha512-T0GUFHBY1B+LkyGk1Df5E1PXwHa7BqvafD4pGvpwWqu8Mu9s/i0kp8YJu6xY//hEC5R8O7V6bfyQJ0S9pUqwQg==",
       "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.97",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.77",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
-        "semver": "^7.3.7",
+        "punycode": "^2.3.0",
+        "semver": "^7.3.8",
+        "table": "^6.8.1",
         "yaml": "1.10.2"
       },
       "dependencies": {
         "@balena/dockerignore": {
           "version": "1.0.2",
+          "bundled": true
+        },
+        "ajv": {
+          "version": "8.12.0",
+          "bundled": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "bundled": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "astral-regex": {
+          "version": "2.0.0",
           "bundled": true
         },
         "at-least-node": {
@@ -5852,8 +6072,27 @@
           "version": "1.6.3",
           "bundled": true
         },
+        "color-convert": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "bundled": true
+        },
         "concat-map": {
           "version": "0.0.1",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
           "bundled": true
         },
         "fs-extra": {
@@ -5871,7 +6110,15 @@
           "bundled": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.2.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
           "bundled": true
         },
         "jsonfile": {
@@ -5884,6 +6131,10 @@
         },
         "jsonschema": {
           "version": "1.4.1",
+          "bundled": true
+        },
+        "lodash.truncate": {
+          "version": "4.4.2",
           "bundled": true
         },
         "lru-cache": {
@@ -5901,19 +6152,66 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "require-from-string": {
+          "version": "2.0.2",
           "bundled": true
         },
         "semver": {
-          "version": "7.3.7",
+          "version": "7.3.8",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
+        "slice-ansi": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "table": {
+          "version": "6.8.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "^8.0.1",
+            "lodash.truncate": "^4.4.2",
+            "slice-ansi": "^4.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1"
+          }
+        },
         "universalify": {
           "version": "2.0.0",
           "bundled": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "bundled": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
         },
         "yallist": {
           "version": "4.0.0",
@@ -7434,7 +7732,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7752,8 +8049,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.11.0",
@@ -7854,7 +8150,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -8442,8 +8737,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@types/js-yaml": "^4.0.5",
-    "aws-cdk-lib": "2.31.1",
+    "aws-cdk-lib": "2.77.0",
     "constructs": "^10.1.78",
     "js-yaml": "^4.1.0",
     "source-map-support": "^0.5.21",


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- These changes are to update the Kubernetes version of the master cluster
- Kubernetes 1.21 is a deprecated version for EKS, so bumping the k8s version 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
