### PR TITLE
Adds retries to teardown in tekton pipelines

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -199,6 +199,7 @@ spec:
       name: cloudwatch
   finally:
   - name: teardown
+    retries: 10 # To deal with throttling during deletion
     params:
     - name: cluster-name
       value: $(params.cluster-name)

--- a/tests/pipelines/eks/awscli-eks-cl2-load.yaml
+++ b/tests/pipelines/eks/awscli-eks-cl2-load.yaml
@@ -187,6 +187,7 @@ spec:
       name: cloudwatch
   finally:    
   - name: teardown
+    retries: 10 # To deal with throttling during deletion
     params:   
     - name: cluster-name
       value: $(params.cluster-name)


### PR DESCRIPTION
This commit adds retries to teardown in tekton pipelines to handle throttling from APIs.
