### PR TITLE
move tekton tasks and pipelines to scalability ns to avoid PSA enforcement at tekton-pipelines namespace level

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -94,7 +94,7 @@ As an example, below are the parmeters used if you want to selectively enable so
 ```shell
 cdk bootstrap
 cdk deploy KITInfrastructure --no-rollback \
-  -c TestNamespace="tekton-pipelines" \
+  -c TestNamespace="scalability" \
   -c TestServiceAccount="tekton-pipelines-executor" \
   -c AWSEBSCSIDriverAddon=false \
   -c KarpenterAddon=false \

--- a/tests/README.md
+++ b/tests/README.md
@@ -11,8 +11,8 @@ Tekton is a powerful and flexible open-source framework for creating CI/CD syste
 ### Installing tekton pipelines
 ```
 cd tests
-kubectl apply -n tekton-pipelines -f tasks -R
-kubectl apply -n tekton-pipelines -f pipelines -R
+kubectl apply -n scalability -f tasks -R
+kubectl apply -n scalability -f pipelines -R
 ```
 
 ### Running a single pipelinerun
@@ -86,7 +86,7 @@ spec:
           containers:
             - name: curl
               image: curlimages/curl
-              args: ["curl", "-X", "POST", "--data", "{}", "el-awscli-eks-load-5k.tekton-pipelines.svc.cluster.local:8080"]
+              args: ["curl", "-X", "POST", "--data", "{}", "el-awscli-eks-load-5k.scalability.svc.cluster.local:8080"]
           restartPolicy: Never
 ---
 apiVersion: triggers.tekton.dev/v1alpha1

--- a/tests/pipelines/cleanup/cronjob.yaml
+++ b/tests/pipelines/cleanup/cronjob.yaml
@@ -39,9 +39,9 @@ spec:
               name: workspace
             env:
               - name: SINK_URL
-                value: "http://el-tekton-cd.tekton-pipelines.svc.cluster.local:8080"
+                value: "http://el-tekton-cd.scalability.svc.cluster.local:8080"
               - name: NAMESPACE
-                value: "tekton-pipelines"
+                value: "scalability"
               - name: CLEANUP_KEEP
                 value: "50"
           restartPolicy: Never

--- a/tests/tasks/addons/cw-metric.yaml
+++ b/tests/tasks/addons/cw-metric.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name:  cloudwatch
-  namespace: tekton-pipelines
+  namespace: scalability
 spec:
   description: "Cloudwatch task publishes the provided metric data points to Amazon CloudWatch. More details can be found in the aws cli reference doc: https://awscli.amazonaws.com/v2/documentation/api/2.1.29/reference/cloudwatch/put-metric-data.html"
   params:

--- a/tests/tasks/addons/fluentbit.yaml
+++ b/tests/tasks/addons/fluentbit.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: eks-addon-fluentbit
-  namespace: tekton-pipelines
+  namespace: scalability
 spec:
   description: |
     This task installs the FluentBit addon on an EKS cluster.

--- a/tests/tasks/generators/manual-deployment/deploy-pods-with-size.yaml
+++ b/tests/tasks/generators/manual-deployment/deploy-pods-with-size.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: deploy-pods-with-size
-  namespace: tekton-pipelines
+  namespace: scalability
   annotations:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Kubernetes
@@ -67,4 +67,3 @@ spec:
       kubectl --kubeconfig=/tmp/kubeconfig apply -f /tmp/deploy.yaml
       echo "Get pods"
       kubectl --kubeconfig=/tmp/kubeconfig get pod -A
-

--- a/tests/tasks/setup/eks/awscli-role.yaml
+++ b/tests/tasks/setup/eks/awscli-role.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: awscli-role-create
-  namespace: tekton-pipelines 
+  namespace: scalability
 spec:
   description: |
     Creates Roles from CFN json stack.

--- a/tests/tasks/teardown/awscli-eks-fargate.yaml
+++ b/tests/tasks/teardown/awscli-eks-fargate.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: awscli-eks-fargate-profile-teardown
-  namespace: tekton-pipelines
+  namespace: scalability
 spec:
   description: |
     Teardown an EKS fargate profile for a cluster.

--- a/tests/tasks/teardown/awscli-vpc-delete.yaml
+++ b/tests/tasks/teardown/awscli-vpc-delete.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: awscli-delete-vpc
-  namespace: tekton-pipelines
+  namespace: scalability
 spec:
   description: |
     This Task can be used to delete CloudFormation stack containing VPC resources that was used for EKS clusters.

--- a/tests/tasks/teardown/kitctl.yaml
+++ b/tests/tasks/teardown/kitctl.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: teardown
-  namespace: tekton-pipelines
+  namespace: scalability
   annotations:
     tekton.dev/pipelines.minVersion: "0.17.0"
     tekton.dev/categories: Kubernetes


### PR DESCRIPTION
Issue #, if available:

Description of changes:
move tekton tasks and pipelines to scalability ns to avoid PSA enforcement at tekton-pipelines namespace level

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
