### PR TITLE
Adds retries for create-eks-cluster

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons.yaml
@@ -67,6 +67,7 @@ spec:
       kind: Task
       name: awscli-role-create
   - name: create-eks-cluster
+    retries: 3
     params:
     - name: cluster-name
       value: $(params.cluster-name)


### PR DESCRIPTION
This commit adds retries for create-eks-cluster to tackle failures when kubectl timeout while getting the kubeconfig.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
