### PR TITLE
Adding support for 1.26, 1.27

### DIFF
--- a/operator/pkg/controllers/master/kubeapiserver.go
+++ b/operator/pkg/controllers/master/kubeapiserver.go
@@ -455,12 +455,25 @@ var (
 	disabledFlagsForAPIServer = map[string]struct{}{"--feature-gates": {}}
 )
 
+var (
+	disabledFlagsForApi126 = map[string]struct{}{"--feature-gates": {}, "--logtostderr": {}}
+)
+
 func apiServerPodSpecForVersion(version string, defaultSpec *v1.PodSpec) v1.PodSpec {
 	switch version {
 	case "1.25":
 		args := []string{}
 		for _, arg := range defaultSpec.Containers[0].Args {
 			if _, skip := disabledFlagsForAPIServer[strings.Split(arg, "=")[0]]; skip {
+				continue
+			}
+			args = append(args, arg)
+		}
+		defaultSpec.Containers[0].Args = args
+	case "1.26", "1.27":
+		args := []string{}
+		for _, arg := range defaultSpec.Containers[0].Args {
+			if _, skip := disabledFlagsForApi126[strings.Split(arg, "=")[0]]; skip {
 				continue
 			}
 			args = append(args, arg)

--- a/operator/pkg/controllers/master/kubecontrollermanager.go
+++ b/operator/pkg/controllers/master/kubecontrollermanager.go
@@ -269,6 +269,14 @@ var (
 	disabledFlagsForKube122 = map[string]struct{}{"--horizontal-pod-autoscaler-use-rest-clients": {}}
 )
 
+var (
+	disabledFlagsForKube126 = map[string]struct{}{"--horizontal-pod-autoscaler-use-rest-clients": {}, "--logtostderr": {}}
+)
+
+var (
+	disabledFlagsForKube127 = map[string]struct{}{"--horizontal-pod-autoscaler-use-rest-clients": {}, "--logtostderr": {}, "--cloud-provider": {}}
+)
+
 func kcmPodSpecForVersion(version string, defaultSpec *v1.PodSpec) v1.PodSpec {
 	switch version {
 	case "1.22", "1.23", "1.24", "1.25":
@@ -280,13 +288,31 @@ func kcmPodSpecForVersion(version string, defaultSpec *v1.PodSpec) v1.PodSpec {
 			args = append(args, arg)
 		}
 		defaultSpec.Containers[0].Args = args
+	case "1.26":
+		args := []string{}
+		for _, arg := range defaultSpec.Containers[0].Args {
+			if _, skip := disabledFlagsForKube126[strings.Split(arg, "=")[0]]; skip {
+				continue
+			}
+			args = append(args, arg)
+		}
+		defaultSpec.Containers[0].Args = args
+	case "1.27":
+		args := []string{}
+		for _, arg := range defaultSpec.Containers[0].Args {
+			if _, skip := disabledFlagsForKube127[strings.Split(arg, "=")[0]]; skip {
+				continue
+			}
+			args = append(args, arg)
+		}
+		defaultSpec.Containers[0].Args = args
 	}
 	return *defaultSpec
 }
 
 func kcmHealthCheckPortForVersion(version string) intstr.IntOrString {
 	switch version {
-	case "1.22", "1.23", "1.24", "1.25":
+	case "1.22", "1.23", "1.24", "1.25", "1.26", "1.27":
 		return intstr.FromInt(10257)
 	}
 	return intstr.FromInt(10252)
@@ -294,7 +320,7 @@ func kcmHealthCheckPortForVersion(version string) intstr.IntOrString {
 
 func kcmHealthCheckSchemeForVersion(version string) v1.URIScheme {
 	switch version {
-	case "1.22", "1.23", "1.24", "1.25":
+	case "1.22", "1.23", "1.24", "1.25", "1.26", "1.27":
 		return v1.URISchemeHTTPS
 	}
 	return v1.URISchemeHTTP

--- a/operator/pkg/utils/imageprovider/imageprovider.go
+++ b/operator/pkg/utils/imageprovider/imageprovider.go
@@ -23,6 +23,8 @@ var (
 		"1.23": kubeVersion123Tag,
 		"1.24": kubeVersion124Tag,
 		"1.25": kubeVersion125Tag,
+		"1.26": kubeVersion126Tag,
+		"1.27": kubeVersion127Tag,
 	}
 )
 
@@ -40,6 +42,8 @@ const (
 	kubeVersion123Tag = "v1.23.13-eks-1-23-9"
 	kubeVersion124Tag = "v1.24.8-eks-1-24-5"
 	kubeVersion125Tag = "v1.25.5-eks-1-25-3"
+	kubeVersion126Tag = "v1.26.7-eks-1-26-17"
+	kubeVersion127Tag = "v1.27.4-eks-1-27-10"
 	repositoryName    = "public.ecr.aws/eks-distro/"
 	busyBoxImage      = "public.ecr.aws/docker/library/busybox:stable"
 )


### PR DESCRIPTION
Description of changes:

Adding support for 1.26 and 1.27 to KIT

Tested the changes for 1.26:
```
% k describe pod -n default kitctl-19-apiserver-5465f95456-tbjpj
Name:                 kitctl-19-apiserver-5465f95456-tbjpj
Namespace:            default
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 ip-10-0-42-210.us-west-2.compute.internal/10.0.42.210
Start Time:           Fri, 15 Sep 2023 18:42:11 -0700
Labels:               kit.k8s.sh/app=apiserver
                      kit.k8s.sh/control-plane-name=kitctl-19
                      pod-template-hash=5465f95456
Annotations:          <none>
Status:               Running
IP:                   10.0.42.210
IPs:
  IP:           10.0.42.210
Controlled By:  ReplicaSet/kitctl-19-apiserver-5465f95456
Containers:
  apiserver:
    Container ID:  containerd://d1b99606bbc6d23414b32a2cc9b0242863f2206d8b91d701d1cde01b9e168a3d
    Image:         public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.7-eks-1-26-17
    Image ID:      public.ecr.aws/eks-distro/kubernetes/kube-apiserver@sha256:04c1fe61eaa5cdde46e155efcbe273060e825585105248a7045bf730e07980ac
    Port:          443/TCP
    Host Port:     443/TCP

% k get pods -n default
NAME                                   READY   STATUS    RESTARTS        AGE
kitctl-19-apiserver-5465f95456-tbjpj   1/1     Running   1 (9m12s ago)   10m
kitctl-19-authenticator-hdw59          1/1     Running   0               10m
kitctl-19-controller-manager-skcmp     1/1     Running   0               10m
kitctl-19-etcd-0                       1/1     Running   0               11m
kitctl-19-etcd-1                       1/1     Running   0               11m
kitctl-19-etcd-2                       1/1     Running   0               11m
kitctl-19-scheduler-7lvmr              1/1     Running   0               10m
```

Tested the changes for 1.27:
```
% k describe pod -n default kitctl-20-apiserver-dc4449d6b-z5pqw
Name:                 kitctl-20-apiserver-dc4449d6b-z5pqw
Namespace:            default
Priority:             2000000000
Priority Class Name:  system-cluster-critical
Node:                 ip-10-0-68-126.us-west-2.compute.internal/10.0.68.126
Start Time:           Fri, 15 Sep 2023 18:46:14 -0700
Labels:               kit.k8s.sh/app=apiserver
                      kit.k8s.sh/control-plane-name=kitctl-20
                      pod-template-hash=dc4449d6b
Annotations:          <none>
Status:               Running
IP:                   10.0.68.126
IPs:
  IP:           10.0.68.126
Controlled By:  ReplicaSet/kitctl-20-apiserver-dc4449d6b
Containers:
  apiserver:
    Container ID:  containerd://978b18baad85b1893ce803bc3d3e89d986dce2dee94d03b18c331756da5f8fff
    Image:         public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.4-eks-1-27-10
    Image ID:      public.ecr.aws/eks-distro/kubernetes/kube-apiserver@sha256:7d115f25b3181869cbc34ba2ac7bec1eb652cdd32c3c6c92288efd202c1a870c
    Port:          443/TCP
    Host Port:     443/TCP


% k get pods -n default
kitctl-20-apiserver-dc4449d6b-z5pqw    1/1     Running   1 (6m15s ago)   7m38s
kitctl-20-authenticator-r8l7z          1/1     Running   0               7m34s
kitctl-20-controller-manager-gh4hv     1/1     Running   1 (6m14s ago)   7m34s
kitctl-20-etcd-0                       1/1     Running   0               8m22s
kitctl-20-etcd-1                       1/1     Running   0               8m22s
kitctl-20-etcd-2                       1/1     Running   0               8m22s
kitctl-20-scheduler-5nx55              1/1     Running   0               7m34s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
