### PR TITLE
Removes the prometheus manifest params

### DIFF
--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -135,7 +135,7 @@ spec:
     script: |
       #!/bin/bash
       if [ -n "$(params.amp-workspace-id)" ]; then
-        CL2_PROMETHEUS_FLAGS="--enable-prometheus-server=true --prometheus-pvc-storage-class gp2 --prometheus-manifest-path=$(workspaces.source.path)/perf-tests/clusterloader2/pkg/prometheus/manifests/"
+        CL2_PROMETHEUS_FLAGS="--enable-prometheus-server=true --prometheus-pvc-storage-class gp2"
       fi
       cat $(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml
       cd $(workspaces.source.path)/perf-tests/clusterloader2/


### PR DESCRIPTION
This commit removes the prometheus manifest params from the load test as that is not required until a explicit manifest needs to be tested.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
