### PR TITLE
Schedule kube-state-pod on same node as Prom pod for resources

### DIFF
--- a/tests/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -162,7 +162,7 @@ spec:
     - name: max-nodes
       value: "1"
     - name: host-instance-types
-      value: m5.4xlarge
+      value: "m5.12xlarge m5.16xlarge r5.12xlarge r5.16xlarge	c5.9xlarge c5.12xlarge"
     - name: host-taints
       value: key=monitoring,value=true,effect=NO_SCHEDULE
     - name: nodegroup-prefix

--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -141,6 +141,15 @@ spec:
                 effect: NoSchedule  
       EOF
       cat $(workspaces.source.path)/perf-tests/clusterloader2/pkg/prometheus/manifests/0prometheus-operator-deployment.yaml
+      # schedule kube-state-pod onto the same node as prometheus
+      cat $(workspaces.source.path)/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
+      cat << EOF >> $(workspaces.source.path)/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
+            tolerations:
+              - key: monitoring
+                operator: Exists
+                effect: NoSchedule  
+      EOF
+      cat $(workspaces.source.path)/perf-tests/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml
       fi
       # Building clusterloader2 binary 
       cd $(workspaces.source.path)/perf-tests/clusterloader2/


### PR DESCRIPTION
Schedule kube-state-pod on same node as Prom pod for resources to avoid pod restarts or scheduling issues for kube-state-metrics pod as it demands[ high resources ](https://github.com/kubernetes/perf-tests/blob/master/clusterloader2/pkg/prometheus/manifests/exporters/kube-state-metrics/deployment.yaml#L29-L37)