### PR TITLE
Adds sleep after creation and teardown

### DIFF
--- a/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -57,7 +57,8 @@ spec:
       if [ "$CREATED_CLUSTER" == "" ]; then
         aws eks create-cluster --name $(params.cluster-name) --region $(params.region) --kubernetes-version $(params.kubernetes-version) --role-arn $SERVICE_ROLE_ARN --resources-vpc-config subnetIds=$subnets,securityGroupIds=$sg $ENDPOINT_FLAG
       fi
-      aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name) 
+      aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name)
+      sleep 300 
   - name: write-kubeconfig
     image: alpine/k8s:1.23.7
     script: |

--- a/tests/tasks/teardown/awscli-eks.yaml
+++ b/tests/tasks/teardown/awscli-eks.yaml
@@ -38,6 +38,7 @@ spec:
           aws eks wait nodegroup-deleted --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region);
       done;
       aws eks delete-cluster --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG
+      sleep 900
   - name: teardown-eks-role-stack
     image: alpine/k8s:1.23.7
     script: |


### PR DESCRIPTION
This commit adds sleep after eks cluster creation because its observed that sometimes dns propagation for the created cluster takes lil bit of time, and after teardown of the eks components to ensure that all the vpc resources are released and ready to be deleted before we start deleting the VPC stack.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
