### PR TITLE
apparently prometheus needs more than 10Gi given we enabled more scra…

### DIFF
--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -160,6 +160,7 @@ spec:
         export PROMETHEUS_SCRAPE_KUBELETS=true
         export PROMETHEUS_SCRAPE_KUBE_STATE_METRICS=true
         export PROMETHEUS_KUBE_PROXY_SELECTOR_KEY=k8s-app
+        export PROMETHEUS_MEMORY_REQUEST=16Gi
       fi
       cat $(workspaces.source.path)/perf-tests/clusterloader2/testing/load/config.yaml
       cd $(workspaces.source.path)/perf-tests/clusterloader2/


### PR DESCRIPTION
Need more memory than the default set here - https://github.com/kubernetes/perf-tests/blob/2c9dc6095a3eb0d083b8abfed5646a9e9b2e293d/clusterloader2/pkg/prometheus/manifests/prometheus-prometheus.yaml#L10 as we are scraping more stuff. Otherwise it gets OOM killed and CL2 tests starts failing.



<img width="955" alt="Screenshot 2023-11-28 at 4 16 29 PM" src="https://github.com/awslabs/kubernetes-iteration-toolkit/assets/53271238/ffda692d-42e2-4694-877c-52ffeb004006">

