### PR TITLE
cluster wait for addons to finish creating

### DIFF
--- a/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -85,5 +85,4 @@ spec:
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
       fi
       aws eks $ENDPOINT_FLAG create-addon --cluster-name $(params.cluster-name) --addon-name eks-pod-identity-agent --addon-version v1.0.0-eksbuild.1
-      # confirm that EKS Pod Identity Agent pods are running
-      kubectl get pods -n kube-system | grep 'eks-pod-identity-agent' 
+      aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name) 


### PR DESCRIPTION
Verified cluster had eks-pod-identity-agent installed

```
sh-4.2$ kubectl get ds -n kube-system
NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
aws-node                 5001      5001      5001    5001         5001        <none>                   114m
ebs-csi-node             5001      5001      5001    5001         5001        kubernetes.io/os=linux   112m
eks-pod-identity-agent   5000      5000      5000    5000         5000        <none>                   112m
kube-proxy               5001      5001      5001    5001         5001        <none>                   114m
sh-4.2$ exit
```