### PR TITLE
Enable statefulsets without pvs

### DIFF
--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -74,9 +74,6 @@ spec:
       CL2_SCHEDULER_THROUGHPUT_THRESHOLD: 90
       PODS_PER_NODE: $(params.pods-per-node)
       CL2_USE_HOST_NETWORK_PODS: false
-      # we are not testing statefulsets at this point
-      SMALL_STATEFUL_SETS_PER_NAMESPACE: 0
-      MEDIUM_STATEFUL_SETS_PER_NAMESPACE: 0
       # we are not testing PVS at this point
       CL2_ENABLE_PVS: false
       ENABLE_SYSTEM_POD_METRICS: false

--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -75,9 +75,6 @@ spec:
       PODS_PER_NODE: $(params.pods-per-node)
       CL2_RATE_LIMIT_POD_CREATION: false
       CL2_USE_HOST_NETWORK_PODS: false
-      # we are not testing statefulsets at this point
-      SMALL_STATEFUL_SETS_PER_NAMESPACE: 0
-      MEDIUM_STATEFUL_SETS_PER_NAMESPACE: 0
       # we are not testing PVS at this point
       CL2_ENABLE_PVS: false
       ENABLE_SYSTEM_POD_METRICS: false


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Reflect load tests to factor in statefulsets to stay closer to cx workload

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
