### PR TITLE
Bump container version in load test

### DIFF
--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.19
+    image: golang:1.22
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)
@@ -145,7 +145,7 @@ spec:
       cd $(workspaces.source.path)/perf-tests/clusterloader2/
       GOOS=linux CGO_ENABLED=0  go build -v -o ./clusterloader ./cmd
   - name: run-loadtest
-    image: alpine/k8s:1.23.7
+    image: alpine/k8s:1.30.2
     onError: continue
     script: |
       #!/bin/bash


### PR DESCRIPTION
Issue #, if available:

Description of changes:
`/src/k8s.io/perf-tests/clusterloader2/go.mod:4: invalid go version '1.22.4': must match format 1.23`
We don't have the minimum golang version need for upstream CL2.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
