### PR TITLE
Disable ooms tracker

### DIFF
--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -91,6 +91,7 @@ spec:
       CL2_ALLOWED_SLOW_API_CALLS: 1
       CL2_PROMETHEUS_NODE_SELECTOR: "eks.amazonaws.com/nodegroup: monitoring-$(params.cluster-name)-nodes-1"
       CL2_PROMETHEUS_MEMORY_SCALE_FACTOR: 4
+      CL2_ENABLE_CLUSTER_OOMS_TRACKER: false
       EOL
       cat $(workspaces.source.path)/overrides.yaml
       cp $(workspaces.source.path)/overrides.yaml $(workspaces.results.path)/overrides.yaml


### PR DESCRIPTION
Issue #, if available:

Description of changes:
CL2 by default enables OOMS_TRACKER https://github.com/kubernetes/perf-tests/blob/ce821d6232cee6719dd86e7e68eee361e337e92a/clusterloader2/testing/load/modules/measurements.yaml#L18 

And OOM_TRACKER lists and watches events here - https://github.com/kubernetes/perf-tests/blob/ce821d6232cee6719dd86e7e68eee361e337e92a/clusterloader2/pkg/measurement/common/ooms_tracker.go#L125-L140 

This has to be disabled to test it along with disabling etcd-page-size patch to see if it helps in short term.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
