### PR TITLE
Update go version

### DIFF
--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.19
+    image: golang:1.22
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)
@@ -73,6 +73,7 @@ spec:
       CL2_DELETE_TEST_THROUGHPUT: $(params.cl2-load-test-throughput)
       CL2_SCHEDULER_THROUGHPUT_THRESHOLD: 70
       PODS_PER_NODE: $(params.pods-per-node)
+      CL2_ENABLE_CLUSTER_OOMS_TRACKER: false
       CL2_RATE_LIMIT_POD_CREATION: false
       CL2_USE_HOST_NETWORK_PODS: false
       # we are not testing PVS at this point
@@ -127,7 +128,7 @@ spec:
       cd $(workspaces.source.path)/perf-tests/clusterloader2/
       GOOS=linux CGO_ENABLED=0  go build -v -o ./clusterloader ./cmd
   - name: run-loadtest
-    image: alpine/k8s:1.23.7
+    image: alpine/k8s:1.30.2
     onError: continue
     script: |
       #!/bin/bash


### PR DESCRIPTION
Issue #, if available:
```
go: errors parsing go.mod:
/src/k8s.io/perf-tests/clusterloader2/go.mod:4: invalid go version '1.22.4': must match format 1.23
```

Description of changes:
update go version

Eventually we need to deprecate this file and just rely on load-slos.yaml once tests get to a stable state.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
