### PR TITLE
set revisionHistoryLimit to 0 for coredns

### DIFF
--- a/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -81,8 +81,10 @@ spec:
       kubectl apply -k "github.com/kubernetes-sigs/aws-ebs-csi-driver/deploy/kubernetes/overlays/stable/?ref=$(params.aws-ebs-csi-driver-version)"
       # TODO: Calculate replicas based on the cluster size going forward.
       # Patching the coredns not to get scheduled on the monitoring node.
+      # Set revisionHistoryLimit to 0 to avoid keeping older replicasets.
       kubectl patch deployment coredns --patch '{
         "spec": {
+          "revisionHistoryLimit": 0,
           "template": {
             "spec": {
               "affinity": {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
We observed that a mixture of old and new replicas can be created when we scale the coredns deployment. This eventually get reconciled to all new pods. But the endpoint can observe the mixture of old and new pods.
Doing this should be able to help.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
