### PR TITLE
bump golang version to 1.23 in clusterloader load-slos template

### DIFF
--- a/tests/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tasks/generators/clusterloader/load-slos.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.22
+    image: golang:1.23
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)


### PR DESCRIPTION
Issue #, if available:

Tests are failing with error:
`go: go.mod requires go >= 1.23.4 (running go 1.22.10; GOTOOLCHAIN=local)`

Upstream change: https://github.com/kubernetes/perf-tests/commit/f4dbd2d89fe67c2362799e8b6509a70a215bab1e


Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
