### PR TITLE
use SA token when accessing apiserver metrics

### DIFF
--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -9,7 +9,7 @@ spec:
   params:
   - name: giturl
     description: "git url to clone the package"
-    default: https://github.com/kubernetes/perf-tests.git
+    default: https://github.com/mengqiy/perf-tests.git
   - name: cl2-branch
     description: "The branch of clusterloader2 you want to use"
     default: "master"


### PR DESCRIPTION
Pick up https://github.com/mengqiy/perf-tests/commit/598e901a2a76e1522d1876e28ea6f447e2a8b1c5 to work around anon auth turn-off.