### PR TITLE
Bump go version for loadtest

### DIFF
--- a/tests/tasks/generators/clusterloader/load.yaml
+++ b/tests/tasks/generators/clusterloader/load.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.22
+    image: golang:1.23
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Bump go version for loadtest 1.22 -> 1.23. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
