### PR TITLE
Add AL2023 launch template task

### DIFF
--- a/tests/assets/eks_node_group_launch_template_al2023.yaml
+++ b/tests/assets/eks_node_group_launch_template_al2023.yaml
@@ -1,0 +1,85 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Create a launch template for use in an autoscaling group of EKS nodes
+  (Amazon Linux 2023)
+Parameters:
+  LaunchTemplateName:
+    Type: String
+    Description: Name of the Launch Template
+  ClusterName:
+    Type: String
+    Description: Name of the Cluster
+  SSHKeyName:
+    Type: String
+    Description: SSH Key Name for EC2 instances
+  APIServerEndpoint:
+    Type: String
+    Description: Kubernetes API Server Endpoint
+  CertificateAuthority:
+    Type: String
+    Description: Certificate Authority data (base64 encoded)
+  ClusterCIDR:
+    Type: String
+    Description: CIDR for cluster (IP range for pods)
+  KubeletConfig:
+    Type: String
+    Description: Kubelet config JSON (will be merged with default config)
+    Default: '{}'
+  AMI:
+    Type: String
+    Description: Launch template ImageId value, which may be an AMI ID or resolve:ssm reference.
+    Default: ''
+Conditions:
+  AMIProvided:
+    !Not [!Equals [!Ref AMI, '']]
+Resources:
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName:
+        Ref: LaunchTemplateName
+      LaunchTemplateData:
+        KeyName:
+          Ref: SSHKeyName
+        BlockDeviceMappings:
+        - DeviceName: "/dev/xvda"
+          Ebs:
+            VolumeSize: 40
+            VolumeType: gp3
+        MetadataOptions:
+          HttpPutResponseHopLimit: 2
+          HttpEndpoint: enabled
+          HttpTokens: required
+        ImageId:
+          !If
+          - AMIProvided
+          - !Ref AMI
+          - !Ref "AWS::NoValue"
+        UserData:
+          Fn::Base64:
+            Fn::Sub: |
+              Content-Type: multipart/mixed; boundary="BOUNDARY"
+              MIME-Version: 1.0
+              
+              --BOUNDARY
+              Content-Type: application/node.eks.aws
+              MIME-Version: 1.0
+              
+              ---
+              apiVersion: node.eks.aws/v1alpha1
+              kind: NodeConfig
+              spec:
+                cluster:
+                  name: ${ClusterName}
+                  apiServerEndpoint: ${APIServerEndpoint}
+                  certificateAuthority: ${CertificateAuthority}
+                  cidr: ${ClusterCIDR}
+                kubelet:
+                  config: ${KubeletConfig}
+
+              --BOUNDARY--
+Outputs:
+  LaunchTemplateName:
+    Description: Name of the Node Group Launch Template
+    Value:
+      Ref: LaunchTemplate

--- a/tests/tasks/setup/eks/awscli-cfn-lt-al2023.yaml
+++ b/tests/tasks/setup/eks/awscli-cfn-lt-al2023.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: awscli-eks-cfn-launch-template-al2023
+  namespace: scalability
+spec:
+  description: |
+    Create an EKS CFN stack to output a launch template for AL2023-based nodes.
+    This Task can be used to create an EKS CFN stack that outputs a launch template.
+    The launch template may be used for a managed nodegroup with or without a custom AMI.
+  params:
+    - name: cluster-name
+      description: EKS cluster you want to create CFN stack for.
+    - name: stack-name
+      description: Stack name you want to spin.
+    - name: region
+      default: "us-west-2"
+      description: The region where the cluster is in.
+    - name: kubernetes-version
+      default: "1.32"
+      description: The EKS version to install.
+    - name: ng-cfn-url
+      description: The url of the CFN YAML/JSON to create CFN stack for NG launch template
+    - name: endpoint
+      default: ""
+    - name: kubelet-config
+      default: "{}"
+      description: "Kubelet config JSON (will be merged with default config)"
+    - name: ami
+      default: ""
+      description: The AMI ID (or SSM parameter) to use for the launch template. If not provided, the launch template will not specify an AMI.
+  workspaces:
+    - name: config
+      mountPath: /config/
+  stepTemplate:
+    env:
+      - name: KUBECONFIG
+        value: /config/kubeconfig
+  steps:
+    - name: create-launch-template
+      image: alpine/k8s:1.23.7
+      script: |
+        set -o xtrace
+        set -o errexit
+        set -o pipefail
+
+        ENDPOINT_FLAG=""
+        if [ -n "$(params.endpoint)" ]; then
+          ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+        fi
+
+        curl -s $(params.ng-cfn-url) -o ./amazon-ng-cfn
+
+        SSH_KEY_NAME=scaletest-nodegroups-ssh-key
+        if [[ "$(aws ec2 --region "$(params.region)" describe-key-pairs --key-names "$SSH_KEY_NAME" --query 'KeyPairs[0].KeyName' --output text)" == "$SSH_KEY_NAME" ]]; then
+            echo "KeyPair '$SSH_KEY_NAME' already exists."
+        else
+            echo "KeyPair not found. Creating a new keypair."
+            # Given these are temp nodes, outputting key for devs to copy it to use for debugging
+            #ToDo - store it in s3 for devs to download it.
+            aws ec2 create-key-pair --region $(params.region) --key-name $SSH_KEY_NAME --query 'KeyMaterial' --output text
+        fi
+
+        aws eks describe-cluster --name $(params.cluster-name) --region $(params.region) --output json > cluster.json
+
+        launch_template_name=$(params.cluster-name)-launchTemplate
+        STACK_NAME=$(params.stack-name)
+        STACK_STATUS=$(aws cloudformation describe-stacks --query 'Stacks[?StackName==`'${STACK_NAME}'`].StackStatus' --output text  --region $(params.region))
+
+        # assemble the stack parameters as a JSON file
+        # the AWS CLI can't handle a JSON string as a ParameterValue in the flag representation
+        # and we need that for kubelet-config
+        jq --null-input \
+            --arg LaunchTemplateName "${launch_template_name}" \
+            --arg ClusterName "$(params.cluster-name)" \
+            --arg SSHKeyName "${SSH_KEY_NAME}" \
+            --arg APIServerEndpoint "$(jq -r .cluster.endpoint cluster.json)" \
+            --arg ClusterCIDR "$(jq -r .cluster.kubernetesNetworkConfig.serviceIpv4Cidr cluster.json)" \
+            --arg CertificateAuthority "$(jq -r .cluster.certificateAuthority.data cluster.json)" \
+            --arg KubeletConfig '$(params.kubelet-config)' \
+            --arg AMI "$(params.ami)" \
+            '$ARGS.named | to_entries | map({"ParameterKey": .key, "ParameterValue": .value})' \
+          > parameters.json
+
+        if [[ "$STACK_STATUS" == "" ]]; then
+            aws cloudformation create-stack \
+                --stack-name $STACK_NAME \
+                --template-body file://$(pwd)/amazon-ng-cfn \
+                --parameters file://$(pwd)/parameters.json \
+                --region $(params.region)
+
+            aws cloudformation wait stack-create-complete --stack-name $STACK_NAME --region $(params.region)
+            echo "CREATED_CFN_STACK=$STACK_NAME"
+        else
+            echo "$STACK_NAME Already exists"
+        fi


### PR DESCRIPTION
Description of changes:

This adds a task, `awscli-eks-cfn-launch-template-al2023`, that creates a launch template compatible with AL2023-based EKS node AMIs.

The launch template may be used for a managed nodegroup, with or without an AMI specified, or an unmanaged nodegroup (autoscaling group).

The launch template includes the ability to pass additional options to the `kubelet`'s config file, via the `KubeletConfig` parameter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
