### PR TITLE
Allow script to continue deleting other resources

### DIFF
--- a/tests/tasks/teardown/awscli-eks.yaml
+++ b/tests/tasks/teardown/awscli-eks.yaml
@@ -27,6 +27,7 @@ spec:
   - name: delete-cluster
     image: alpine/k8s:1.23.7
     script: |
+      set +e
       ENDPOINT_FLAG=""
       if [ -n "$(params.endpoint)" ]; then
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
@@ -37,7 +38,11 @@ spec:
           aws eks delete-nodegroup --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region);
           aws eks wait nodegroup-deleted --nodegroup-name $i --cluster-name $(params.cluster-name) $ENDPOINT_FLAG --region $(params.region);
       done;
+      echo "Starting to delete cluster..."
       aws eks delete-cluster --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG
+      echo "Waiting for cluster to be deleted..."
+      aws eks wait cluster-deleted --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG
+      echo "Cluster is deleted..."
   - name: teardown-eks-role-stack
     image: alpine/k8s:1.23.7
     script: |


### PR DESCRIPTION
Allow script to continue deleting other resources even if delete cluster failed.
Also add to wait for cluster deletion.

Issue #, if available:

Cluster teardown in tekton pipeline exit early due to cluster not found and hence never reached to delete VPC and other resources. Cluster delete step should not exit early or block the entire teardown workflow.

Description of changes:
Add set +e to allow the script to continue execution even if a command fails.
Add wait command to wait for cluster deletion in case VPC stack deletion fail due to resources like subnet still attached to cluster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
