### PR TITLE
update action/cache version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -21,7 +21,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.1'
+          go-version: "1.17.1"
       - name: Build & Test
         run: |
           echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH
@@ -34,20 +34,21 @@ jobs:
         arch: ["amd64"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-          ~/go/bin/
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2
-      with:
-        go-version: '1.17.1'
-    - name: Build the KIT CLI
-      run: |
-        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitctl ./cmd/kitctl/
-      working-directory: substrate
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin/
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.1"
+      - name: Build the KIT CLI
+        run: |
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitctl ./cmd/kitctl/
+        working-directory: substrate
+

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,4 +1,3 @@
-
 name: Build the operator image and push to public ECR on the main branch
 on:
   push:
@@ -9,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -20,7 +19,7 @@ jobs:
             ${{ runner.os }}-go-
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.1'
+          go-version: "1.17.1"
       - name: Build & Test
         run: |
           echo "/usr/local/kubebuilder/bin" >> $GITHUB_PATH

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release operator version, generates a new Docker image and helm charts
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
   workflow_dispatch: {}
 jobs:
   release:
@@ -10,8 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.1'
-      - uses: actions/cache@v2
+          go-version: "1.17.1"
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/go-build
@@ -55,43 +55,43 @@ jobs:
         arch: ["amd64"]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-          ~/go/bin/
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Set env
-      run: |
-        echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - uses: actions/setup-go@v3
-      with:
-        go-version: '1.17.1'
-    - name: Build the KIT CLI
-      run: |
-        GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitctl ./cmd/kitctl/
-        zip ./bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip -j ./bin/kitctl
-      working-directory: substrate
-    - name: Attach the binary to release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: "./substrate/bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    - name: Update brew formulae
-      uses: mislav/bump-homebrew-formula-action@v1
-      with:
-        formula-name: kitctl
-        formula-path: kitctl.rb
-        homebrew-tap: awslabs/kubernetes-iteration-toolkit
-        base-branch: main
-        download-url: https://github.com/awslabs/kubernetes-iteration-toolkit/releases/download/${{ env.RELEASE_VERSION }}/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip
-        commit-message: |
-          Update kitctl to ${{ env.RELEASE_VERSION }}
-          Created by Github actions during Release CLI action
-      env:
-        COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+            ~/go/bin/
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Set env
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - uses: actions/setup-go@v3
+        with:
+          go-version: "1.17.1"
+      - name: Build the KIT CLI
+        run: |
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o ./bin/kitctl ./cmd/kitctl/
+          zip ./bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip -j ./bin/kitctl
+        working-directory: substrate
+      - name: Attach the binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "./substrate/bin/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update brew formulae
+        uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          formula-name: kitctl
+          formula-path: kitctl.rb
+          homebrew-tap: awslabs/kubernetes-iteration-toolkit
+          base-branch: main
+          download-url: https://github.com/awslabs/kubernetes-iteration-toolkit/releases/download/${{ env.RELEASE_VERSION }}/kitctl_${{ env.RELEASE_VERSION }}_${{ matrix.os }}_${{ matrix.arch }}.zip
+          commit-message: |
+            Update kitctl to ${{ env.RELEASE_VERSION }}
+            Created by Github actions during Release CLI action
+        env:
+          COMMITTER_TOKEN: ${{ secrets.UPLOAD_GITHUB_TOKEN }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Updating action/cache to v4 to fix action failures. Following  https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
