### PR TITLE
Update golang images to 1.24 to fix load failures

### DIFF
--- a/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
@@ -78,7 +78,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.23
+    image: golang:1.24
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-slos.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.23
+    image: golang:1.24
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.23
+    image: golang:1.24
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Seeing failures for pod identity prepare-loadtests due to `go: go.mod requires go >= 1.24.1 (running go 1.23.7; GOTOOLCHAIN=local)`. Updating all golang images
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
