### PR TITLE
Add/fix obelisk/journal test

### DIFF
--- a/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -96,6 +96,15 @@ spec:
     type: string
   - name: ng-cfn-url-monitoring
     default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_node_group_launch_template.json"
+  - name: dataplane-configuration
+    default: ""
+    type: string
+  - name: eksadm-s3-path
+    default: ""
+    type: string
+  - name: cluster-type
+    default: "raft"
+    type: string
   tasks:
   - name: slack-notification
     params:
@@ -153,6 +162,12 @@ spec:
       value: $(params.cluster-name)
     - name: kubernetes-version
       value: $(params.kubernetes-version)
+    - name: dataplane-configuration
+      value: $(params.dataplane-configuration)
+    - name: eksadm-s3-path
+      value: $(params.eksadm-s3-path)
+    - name: cluster-type
+      value: $(params.cluster-type)
     retries: 3
     runAfter:
     - create-cluster-node-role
@@ -358,7 +373,7 @@ spec:
     - name: value
       value: $(tasks.generate-eks-pod-identity.results.datapoint)
     - name: namespace
-      value: eks-pod-identity-$(params.kubernetes-version)
+      value: eks-pod-identity-$(params.kubernetes-version)-$(params.cluster-type)
     runAfter:
     - generate-eks-pod-identity
     taskRef:
@@ -371,7 +386,7 @@ spec:
     - name: value
       value: $(tasks.generate.results.datapoint)
     - name: namespace
-      value: $(params.kubernetes-version)
+      value: $(params.kubernetes-version)-$(params.cluster-type)
     runAfter:
     - generate
     taskRef:

--- a/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -30,6 +30,12 @@ spec:
   - name: aws-pod-identity-agent-version
     default: v1.3.5-eksbuild.2
     description: The release version for aws pod identity agent.
+  - name: dataplane-configuration
+    description: ""
+  - name: eksadm-s3-path
+    description: ""
+  - name: cluster-type
+    description: ""
   workspaces:
   - name: config
     mountPath: /config/
@@ -58,7 +64,14 @@ spec:
       echo "securitygroup=$sg"
 
       if [ "$CREATED_CLUSTER" == "" ]; then
-        aws eks create-cluster --name $(params.cluster-name) --region $(params.region) --kubernetes-version $(params.kubernetes-version) --role-arn $SERVICE_ROLE_ARN --resources-vpc-config subnetIds=$subnets,securityGroupIds=$sg $ENDPOINT_FLAG
+        if [ -n "$(params.dataplane-configuration)" ] && [ -n "$(params.eksadm-s3-path)" ]  && [ "$(params.cluster-type)" = "obelisk" ]; then
+          aws s3 cp $(params.eksadm-s3-path) ./eksadm # Download eksadm binary to create the cluster that is obelisk/journal based
+          chmod +x eksadm
+          echo "Creating cluster using eksadm..."
+          ./eksadm createCluster $ENDPOINT_FLAG --kubernetes-version $(params.kubernetes-version) --region $(params.region) --dataplane-configuration $(params.dataplane-configuration) --cluster-name $(params.cluster-name) --role-arn $SERVICE_ROLE_ARN --subnet-ids $subnets --security-group-ids $sg
+        else
+          aws eks create-cluster --name $(params.cluster-name) --region $(params.region) --kubernetes-version $(params.kubernetes-version) --role-arn $SERVICE_ROLE_ARN --resources-vpc-config subnetIds=$subnets,securityGroupIds=$sg $ENDPOINT_FLAG
+        fi
       fi
       aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name)
   - name: write-kubeconfig


### PR DESCRIPTION
Issue #, if available:
Obelisk periodic test has been failing.

Description of changes:
The test failure occurred because the slos pipeline (https://github.com/awslabs/kubernetes-iteration-toolkit/blob/main/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml) was recently updated, but the Obelisk test pipeline (which was originally a copy of the slos pipeline with an additional journal migration task) wasn't updated to match. To prevent similar issues in the future, we should incorporate the obelisk/journal based cluster creation directly into the slos pipeline.

This approach would result in a single, unified pipeline for both Obelisk and non-Obelisk tests, eliminating the need to maintain separate pipelines and reducing the risk of inconsistencies.

For example, if we pass dataplane-configuration, eksadm-s3-path and cw-metrics-namespace it will create a obelisk/journal based cluster. This new workflow will not break the existing jobs/workflow. 

TODO:
Once this gets merged and synced to scalability account KIT cluster. 
1 Update the pipelinerun cronjob internally for both obelisk and non-obelisk. 
2 Set alarm in CW in scalability account (namespace will be changed (ex. from 1.32 to 1.32-raft) so need to update ALL in scalability account)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


Edit:
I'm closing the PR as we move this change into internal code package. 
