### PR TITLE
Delete ASG before VPC

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -115,8 +115,8 @@ spec:
       #!/bin/bash
       aws sts get-caller-identity
       # Check if the stack exists
-      DESCRIBE_STACK=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name))
-      if [ -z $DESCRIBE_STACK ]; then
+      aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name)
+      if [ $? -ne 0 ]; then
         echo "Stack $(params.cluster-name) not found. Exiting..."
         exit 1
       else

--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -128,7 +128,7 @@ spec:
       aws cloudformation wait stack-delete-complete --region $(params.region) --stack-name $(params.cluster-name)
       if [ $? -ne 0 ]; then
         # Get vpc id from stack that is blocking deletion
-        VPC_ID=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name) | jq -r '.[].[].Outputs.[] | select(.OutputKey == "VpcId") | .OutputValue')
+        VPC_ID=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name) | jq -r '.Stacks[].Outputs[] | select(.OutputKey == "VpcId") | .OutputValue')
         echo "$VPC_ID"
         # Get security group ids from vpc that is blocking deletion. Have to get the security group this way because it doesn't report as part
         # of the stack. Filter only security groups with cluster-name key to prevent deleting default sg

--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -71,14 +71,52 @@ spec:
       if [ -n "$(params.slack-hook)" ]; then
         curl -H "Content-type: application/json" --data '{"Message": "$(params.slack-message)"}' -X POST  $(params.slack-hook)
       fi
+  - name: awscli-delete-asg
+    image: alpine/k8s:1.23.7
+    script: |
+      #!/bin/bash
+      set -e
+      aws sts get-caller-identity 
+      # Stack ids for self managed node groups will have pattern <cluster-name>-nodes-<num>
+      STACK_IDS=$(aws cloudformation describe-stacks \
+        --region $(params.region) \
+        --query 'Stacks[?contains(StackName, `'$(params.cluster-name)'-nodes-`)].StackName' \
+        --output text)
+      
+      if [ -z "$STACK_IDS" ]; then
+        echo "No stacks found matching pattern: $(params.cluster-name)-nodes-"
+        exit 0
+      fi
+      
+      echo "Found stacks to delete: $STACK_IDS"
+      # Delete each stack and wait for completion
+      for stack_name in $STACK_IDS; do
+        echo "Deleting stack: $stack_name"
+        
+        # Delete the stack
+        aws cloudformation delete-stack \
+          --region $(params.region) \
+          --stack-name "$stack_name"
+        
+        echo "Waiting for stack deletion to complete..."
+        
+        # Wait for deletion to complete
+        aws cloudformation wait stack-delete-complete \
+          --region $(params.region) \
+          --stack-name "$stack_name"
+        
+        echo "Stack $stack_name deleted successfully!"
+      done
+      
+      echo "All matching stacks have been deleted!"
   - name: awscli-delete-vpc
     image: alpine/k8s:1.23.7
     script: |
       #!/bin/bash
       aws sts get-caller-identity
       # Check if the stack exists
-      aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name)
-      if [ $? -ne 0 ]; then
+      DESCRIBE_STACK=$(aws cloudformation --region $(params.region) describe-stacks --stack-name $(params.cluster-name))
+      if [ -z $DESCRIBE_STACK ]; then
         echo "Stack $(params.cluster-name) not found. Exiting..."
         exit 1
       else
@@ -120,41 +158,3 @@ spec:
       else
         echo "Stack deleted successfully!"
       fi
-  - name: awscli-delete-asg
-    image: alpine/k8s:1.23.7
-    script: |
-      #!/bin/bash
-      set -e
-      aws sts get-caller-identity 
-      # Stack ids for self managed node groups will have pattern <cluster-name>-nodes-<num>
-      STACK_IDS=$(aws cloudformation describe-stacks \
-        --region $(params.region) \
-        --query 'Stacks[?contains(StackName, `'$(params.cluster-name)'-nodes-`)].StackName' \
-        --output text)
-      
-      if [ -z "$STACK_IDS" ]; then
-        echo "No stacks found matching pattern: $(params.cluster-name)-nodes-"
-        exit 0
-      fi
-      
-      echo "Found stacks to delete: $STACK_IDS"
-      # Delete each stack and wait for completion
-      for stack_name in $STACK_IDS; do
-        echo "Deleting stack: $stack_name"
-        
-        # Delete the stack
-        aws cloudformation delete-stack \
-          --region $(params.region) \
-          --stack-name "$stack_name"
-        
-        echo "Waiting for stack deletion to complete..."
-        
-        # Wait for deletion to complete
-        aws cloudformation wait stack-delete-complete \
-          --region $(params.region) \
-          --stack-name "$stack_name"
-        
-        echo "Stack $stack_name deleted successfully!"
-      done
-      
-      echo "All matching stacks have been deleted!"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

During the run pipeline task. Previously when `awscli-delete-vpc` step failed silently. #505 introduced `exit 1` https://github.com/awslabs/kubernetes-iteration-toolkit/pull/505/files#diff-e7382abe190bafb110b51bfc8b383cce09de81c48c63cd9272a7cf6c6227f7cbR116 failures which prevents`awscli-delete-asg` step from running. Which leaves more resources connected to the VPC further preventing deletion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
