### PR TITLE
Fix jq notation in delete vpc get group id

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -132,7 +132,7 @@ spec:
         echo "$VPC_ID"
         # Get security group ids from vpc that is blocking deletion. Have to get the security group this way because it doesn't report as part
         # of the stack. Filter only security groups with cluster-name key to prevent deleting default sg
-        SG_IDS=$(aws ec2 describe-security-groups --region $(params.region) --filters 'Name=vpc-id, Values='$VPC_ID | jq -r '.[].[] | select(. | select(.Tags != null) | .Tags.[] | select(.Key == "aws:eks:cluster-name")) | .GroupId')
+        SG_IDS=$(aws ec2 describe-security-groups --region $(params.region) --filters 'Name=vpc-id, Values='$VPC_ID | jq -r '.SecurityGroups[] | select(. | select(.Tags != null) | .Tags[] | select(.Key == "aws:eks:cluster-name")) | .GroupId')
         echo "$SG_IDS"
         for sg in $SG_IDS; do
           echo "deleting security group $sg"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Delete VPC resources is getting this error.
```
jq: error: syntax error, unexpected '[', expecting FORMAT or QQSTRING_START (Unix shell quoting issues?) at <top-level>, line 1:
.[].[] | select(. | select(.Tags != null) | .Tags.[] | select(.Key == "aws:eks:cluster-name")) | .GroupId    
jq: 1 compile error
```

The change is similar to previous fix for #508 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
