### PR TITLE
Update pod-identity-agent version for scale test

### DIFF
--- a/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-vpc.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-vpc.yaml
@@ -28,7 +28,7 @@ spec:
     default: release-1.13
     description: The release version for aws ebs csi driver.
   - name: aws-pod-identity-agent-version
-    default: v1.3.5-eksbuild.2
+    default: v1.3.7-eksbuild.2
     description: The release version for aws pod identity agent.
   workspaces:
   - name: config


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Update pod-identity-agent version for scale test, v1.3.7-eksbuild.2 is the latest addon version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
