### PR TITLE
Calculate metrics of credential fetching from Pods & upload to s3

### DIFF
--- a/tests/assets/eks-pod-identity/config.yaml
+++ b/tests/assets/eks-pod-identity/config.yaml
@@ -1,3 +1,4 @@
+{{$clusterName := DefaultParam .CL2_CLUSTER_NAME "default-cluster-name"}}
 {{$namespacePrefix := DefaultParam .CL2_NAMESPACE_PREFIX "default"}}
 {{$namespaceCount := DefaultParam .CL2_NAMESPACE_COUNT 1}}
 {{$totalEksPodIdentityPods := DefaultParam .CL2_EKS_POD_IDENTITY_PODS 5000}}
@@ -42,6 +43,7 @@ steps:
       objectTemplatePath: pod-default.yaml
       templateFillMap:
         Group: eks-pod-identity
+        ClusterName: {{$clusterName}}
 - name: Waiting for eks pod identity pods to be created
   measurements:
   - Identifier: WaitForEksPodIdentityPods

--- a/tests/assets/eks-pod-identity/pod-default.yaml
+++ b/tests/assets/eks-pod-identity/pod-default.yaml
@@ -6,18 +6,82 @@ metadata:
     group: {{.Group}}
 spec:
   containers:
-  - image: registry.k8s.io/pause:3.9
-    imagePullPolicy: IfNotPresent
-    name: pause
-  initContainers:
-  - name: app-init
+  - name: app-with-awsapi
     image: public.ecr.aws/aws-cli/aws-cli:latest
     imagePullPolicy: IfNotPresent
+    env:
+      - name: CLUSTER_NAME
+        value: "{{.ClusterName}}"
     command:
       - sh
       - -c
       - |
+        AUTH_TOKEN=$(cat $AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE)
+        MAX_ATTEMPTS=7
+        INITIAL_DELAY=0.2  # 200ms
+
+        NAMESPACE="EKSPodIdentityScalabilityTests"
+        DIMENSION_NAME="ClusterName"
+        DIMENSION_VALUE=$CLUSTER_NAME
+        METRIC_LATENCY_NAME="CredentialFetchLatency"
+        PERIOD=300
+
+        METRIC_MAX_RETRIES=5
+        METRIC_RETRY_DELAY=1
+
+        start_epoch=$(date +%s%3N)
+        # fetch credentials
+        for i in $(seq 0 $((MAX_ATTEMPTS - 1))); do
+          if curl -S -H "Authorization: $AUTH_TOKEN" http://169.254.170.23/v1/credentials; then
+            end_epoch=$(date +%s%3N)
+            printf "Endpoint is reachable at try %d\n" "$i"
+
+            latency_ms=$((end_epoch - start_epoch))
+            latency_sec=$(awk "BEGIN { print $latency_ms / 1000 }")
+
+            # send CredentialFetchLatency metric
+            for ((j=1; j<=METRIC_MAX_RETRIES; j++)); do
+              aws cloudwatch put-metric-data \
+                --namespace "$NAMESPACE" \
+                --metric-name "$METRIC_LATENCY_NAME" \
+                --dimensions "$DIMENSION_NAME=$DIMENSION_VALUE" \
+                --value "$latency_sec" \
+                --unit Seconds && {
+                  echo "Metric CredentialFetchLatency sent successfully."
+                  break
+              }
+
+              if [ "$j" -lt "$METRIC_MAX_RETRIES" ]; then
+                echo "Attempt $j failed. Retrying in $METRIC_RETRY_DELAY seconds..." >&2
+                sleep $METRIC_RETRY_DELAY
+                METRIC_RETRY_DELAY=$((METRIC_RETRY_DELAY * 2)) # exponential backoff
+              else
+                echo "Failed to send metric CredentialFetchLatency after $METRIC_MAX_RETRIES attempts." >&2
+                exit 1
+              fi
+            done
+
+            break
+          fi
+
+          if [ "$i" -eq $((MAX_ATTEMPTS - 1)) ]; then
+            echo "Max attempts reached. Exiting with failure."
+            exit 1
+          fi
+
+          SLEEP_TIME=$(echo "$INITIAL_DELAY * (2 ^ $i)" | bc -l)
+          printf "Failed. Sleeping %.3f seconds before retry...\n" "$SLEEP_TIME"
+          sleep "$SLEEP_TIME"
+        done
+
+        # s3 api call
         while ! aws s3 ls; do
             echo "Waiting for S3 bucket access..."
         done
         echo "S3 bucket is accessible, proceeding."
+
+        # pause
+        while true; do
+            echo "Sleeping for 1 hour..."
+            sleep 3600
+        done

--- a/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -195,7 +195,7 @@ spec:
         value: "$(params.ng-cfn-url)"
       - name: endpoint
         value: $(params.endpoint)
-      - name: node-role-name 
+      - name: node-role-name
         value: $(params.cluster-name)-node-role
       - name: ami
         value: $(params.launch-template-ami)
@@ -297,6 +297,8 @@ spec:
       value: $(params.desired-nodes)
     - name: cluster-name
       value: $(params.cluster-name)
+    - name: endpoint
+      value: $(params.endpoint)
     - name: namespace-prefix
       value: $(params.namespace-prefix)
     - name: namespace-count

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
@@ -35,6 +35,8 @@ spec:
     description: The region where the cluster is in.
   - name: cluster-name
     description: "The name of the EKS cluster you want to spin"
+  - name: endpoint
+    default: ""
   - name: namespace-prefix
     default: "default"
     description: "The prefix of namespaces for EKS Pod Identity test."
@@ -89,6 +91,7 @@ spec:
       CL2_DEFAULT_QPS: $(params.cl2-default-qps)
       CL2_DEFAULT_BURST: $(params.cl2-default-burst)
       CL2_UNIFORM_QPS: $(params.cl2-uniform-qps)
+      CL2_CLUSTER_NAME: $(params.cluster-name)
       CL2_NAMESPACE_PREFIX: $(params.namespace-prefix)
       CL2_NAMESPACE_COUNT: $(params.namespace-count)
       CL2_TIMEOUT_EKS_POD_IDENTITY_POD_CREATION: $(params.timeout-pia-pod-creation)
@@ -175,6 +178,68 @@ spec:
       S3_RESULT_PATH=$(cat $(results.s3_result.path))
       echo "S3 Path: $S3_RESULT_PATH"
       aws sts get-caller-identity
+
+      REGION=$(params.region)
+      ENDPOINT_FLAG=""
+      if [ -n "$(params.endpoint)" ]; then
+        ENDPOINT_FLAG="--endpoint $(params.endpoint)"
+      fi
+
+      CLUSTER_NAME=$(params.cluster-name)
+      NAMESPACE="EKSPodIdentityScalabilityTests"
+      DIMENSION_NAME="ClusterName"
+      DIMENSION_VALUE=$CLUSTER_NAME
+      METRIC_LATENCY_NAME="CredentialFetchLatency"
+      PERIOD=300
+
+      START_TIME=$(aws eks $ENDPOINT_FLAG --region $REGION describe-cluster \
+        --name "$CLUSTER_NAME" \
+        --query "cluster.createdAt" \
+        --output text)
+
+      END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      response=$(aws cloudwatch get-metric-statistics \
+        --region "$REGION" \
+        --namespace "$NAMESPACE" \
+        --metric-name "$METRIC_LATENCY_NAME" \
+        --dimensions Name="$DIMENSION_NAME",Value="$DIMENSION_VALUE" \
+        --start-time "$START_TIME" \
+        --end-time "$END_TIME" \
+        --period "$PERIOD" \
+        --extended-statistics p50 p90 p99 \
+        --output json)
+
+      # extract p50 p90 p99
+      latest=$(echo "$response" | jq -r '.Datapoints | sort_by(.Timestamp) | last')
+      p50=$(echo "$latest" | jq -r '."ExtendedStatistics"."p50" // "N/A"')
+      p90=$(echo "$latest" | jq -r '."ExtendedStatistics"."p90" // "N/A"')
+      p99=$(echo "$latest" | jq -r '."ExtendedStatistics"."p99" // "N/A"')
+
+      response=$(aws cloudwatch get-metric-statistics \
+        --region "$REGION" \
+        --namespace "$NAMESPACE" \
+        --metric-name "$METRIC_LATENCY_NAME" \
+        --dimensions Name="$DIMENSION_NAME",Value="$DIMENSION_VALUE" \
+        --start-time "$START_TIME" \
+        --end-time "$END_TIME" \
+        --period "$PERIOD" \
+        --statistics SampleCount \
+        --output json)
+
+      total_samples=$(echo "$response" | jq '[.Datapoints[].SampleCount] | add // 0')
+
+      cat <<EOF > eks_pod_identity_test_summary.json
+      {
+        "start_time": "$START_TIME",
+        "end_time": "$END_TIME",
+        "total_samples": $total_samples,
+        "p50": $p50,
+        "p90": $p90,
+        "p99": $p99
+      }
+      EOF
+
       # we expect to see all files from loadtest that clusterloader2 outputs here in this dir
       ls -larth
       aws s3 cp . s3://$S3_RESULT_PATH/  --recursive

--- a/tests/tekton-resources/tasks/setup/eks/awscli-pod-identity-association.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-pod-identity-association.yaml
@@ -48,7 +48,8 @@ spec:
         ENDPOINT_FLAG="--endpoint $(params.endpoint)"
       fi
 
-      MANAGED_POLICY_ARN="arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      S3_MANAGED_POLICY_ARN="arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+      CLOUDWATCH_MANAGED_POLICY_ARN="arn:aws:iam::aws:policy/CloudWatchFullAccess"
       TRUST_POLICY_FILE="pia-trust-policy.json"
       # create a trust policy json file
       curl -s $(params.pia-trust-policy-url) -o ./$TRUST_POLICY_FILE
@@ -57,7 +58,8 @@ spec:
 
         PIA_ROLE_NAME=$(params.cluster-name)-pia-role-$i
         aws iam create-role --role-name $PIA_ROLE_NAME --assume-role-policy-document file://$TRUST_POLICY_FILE
-        aws iam attach-role-policy --role-name $PIA_ROLE_NAME --policy-arn $MANAGED_POLICY_ARN
+        aws iam attach-role-policy --role-name $PIA_ROLE_NAME --policy-arn $S3_MANAGED_POLICY_ARN
+        aws iam attach-role-policy --role-name $PIA_ROLE_NAME --policy-arn $CLOUDWATCH_MANAGED_POLICY_ARN
         PIA_ROLE_ARN=$(aws iam get-role --role-name $PIA_ROLE_NAME --query 'Role.Arn' --output text)
         echo "$PIA_ROLE_ARN is created"
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

1. Change Pod spec to invoke Pod Identity in normal container instead of from initContainer
2. Push credential fetching metrics
3. Push credential fetching time range, sample count, p50, p90 and p99 to s3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
