### PR TITLE
Robust-node-deletion

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -103,12 +103,6 @@ spec:
       aws cloudformation delete-stack --stack-name $(params.service-role-stack-name)
       aws cloudformation delete-stack --stack-name $(params.node-role-stack-name)
       aws cloudformation delete-stack --stack-name $(params.launch-template-stack-name)
-  - name: send-slack-notification
-    image: alpine/k8s:1.23.7
-    script: |
-      if [ -n "$(params.slack-hook)" ]; then
-        curl -H "Content-type: application/json" --data '{"Message": "$(params.slack-message)"}' -X POST  $(params.slack-hook)
-      fi
   - name: awscli-delete-vpc
     image: alpine/k8s:1.23.7
     script: |
@@ -157,4 +151,10 @@ spec:
         fi
       else
         echo "Stack deleted successfully!"
+      fi
+  - name: send-slack-notification
+    image: alpine/k8s:1.23.7
+    script: |
+      if [ -n "$(params.slack-hook)" ]; then
+        curl -H "Content-type: application/json" --data '{"Message": "$(params.slack-message)"}' -X POST  $(params.slack-hook)
       fi


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Delete node-roles after ASGs have been deleted fully. Premature deletion of the node-role could lead to failed cloud formation stack deletion since some instance-profiles still have the node-role attached to them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
