### PR TITLE
Wait for launch-template-stack deletion to avoid race conditions with node-role stack deletion

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -101,8 +101,12 @@ spec:
     image: alpine/k8s:1.23.7
     script: |
       aws cloudformation delete-stack --stack-name $(params.service-role-stack-name)
-      aws cloudformation delete-stack --stack-name $(params.node-role-stack-name)
       aws cloudformation delete-stack --stack-name $(params.launch-template-stack-name)
+      # wait for the launch-template stack to be completely deleted to avoid race-conditions.
+      echo "waiting for launch-template stack deletion..."
+      aws cloudformation wait stack-delete-complete --stack-name $(params.launch-template-stack-name)"
+      aws cloudformation delete-stack --stack-name $(params.node-role-stack-name) --deletion-mode FORCE_DELETE_STACK
+      
   - name: awscli-delete-vpc
     image: alpine/k8s:1.23.7
     script: |


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The launch-template stack creates an instance-profile that uses the said node-role. Earlier we were deleting the node-role before this launch-template stack was being deleted which could lead to stack deletion errors due to node-role still being in use. This change moves the launch-template-stack deletion before node-role deletion and waits for successful deletion of the launch-template-stack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
