### PR TITLE
fix: updated base-image for teardown task as --deletion-mode option was enabled in awscli > 1.33

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -98,7 +98,7 @@ spec:
       
       echo "All matching stacks have been deleted!"
   - name: teardown-eks-role-stack
-    image: alpine/k8s:1.23.7
+    image: alpine/k8s:1.30.2
     script: |
       aws cloudformation delete-stack --stack-name $(params.service-role-stack-name)
       aws cloudformation delete-stack --stack-name $(params.launch-template-stack-name)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
teardown step would fail since `--deletion-mode FORCE_DELETE_STACK` is a stack deletion mode that is available in 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
