### PR TITLE
handle stack deletion if the stack was never deleted before

### DIFF
--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -105,7 +105,7 @@ spec:
       # wait for the launch-template stack to be completely deleted to avoid race-conditions.
       echo "waiting for launch-template stack deletion..."
       aws cloudformation wait stack-delete-complete --stack-name $(params.launch-template-stack-name)
-      aws cloudformation delete-stack --stack-name $(params.node-role-stack-name) --deletion-mode FORCE_DELETE_STACK
+      aws cloudformation delete-stack --stack-name $(params.node-role-stack-name)
       
   - name: awscli-delete-vpc
     image: alpine/k8s:1.23.7

--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -105,7 +105,14 @@ spec:
       # wait for the launch-template stack to be completely deleted to avoid race-conditions.
       echo "waiting for launch-template stack deletion..."
       aws cloudformation wait stack-delete-complete --stack-name $(params.launch-template-stack-name)
-      aws cloudformation delete-stack --stack-name $(params.node-role-stack-name)
+      STACK_STATUS=$(aws cloudformation describe-stacks --stack-name $(params.node-role-stack-name) --query 'Stacks[0].StackStatus' --output text || echo "STACK_NOT_FOUND")
+      if [ "$STACK_STATUS" == "DELETE_FAILED" ]; then
+          echo "Stack is in DELETE_FAILED state, using FORCE_DELETE_STACK"
+          aws cloudformation delete-stack --stack-name $(params.node-role-stack-name) --deletion-mode FORCE_DELETE_STACK
+      else
+          echo "Normal stack deletion"
+          aws cloudformation delete-stack --stack-name $(params.node-role-stack-name)
+      fi
       
   - name: awscli-delete-vpc
     image: alpine/k8s:1.23.7

--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -106,6 +106,7 @@ spec:
       echo "waiting for launch-template stack deletion..."
       aws cloudformation wait stack-delete-complete --stack-name $(params.launch-template-stack-name)
       STACK_STATUS=$(aws cloudformation describe-stacks --stack-name $(params.node-role-stack-name) --query 'Stacks[0].StackStatus' --output text || echo "STACK_NOT_FOUND")
+      echo $STACK_STATUS
       if [ "$STACK_STATUS" == "DELETE_FAILED" ]; then
           echo "Stack is in DELETE_FAILED state, using FORCE_DELETE_STACK"
           aws cloudformation delete-stack --stack-name $(params.node-role-stack-name) --deletion-mode FORCE_DELETE_STACK


### PR DESCRIPTION
Issue #, if available:

Description of changes:
You can only use force-deletion of a stack if the stack is in DELETE_FAILED state. 
```
An error occurred (ValidationError) when calling the DeleteStack operation: Invalid operation on stack [arn:aws:cloudformation:u<stack-name>]. You can activate DeletionMode FORCE_DELETE_STACK in a delete stack operation only when the stack is in the DELETE_FAILED state.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

### Testing details:
```
docker run -it alpine/k8s:1.30.2 bash
5090a9d2b508:/apps# aws --version
aws-cli/1.33.18 Python/3.12.3 Linux/5.10.237-211.948.amzn2int.x86_64 botocore/1.34.136

5090a9d2b508:/apps# aws configure # setup accesskey, and secret, region
```

1. Test-case 1: Stack deletion had failed:
```
5090a9d2b508:/apps# export NODE_ROLE_STACK_NAME=dummy_node_role_delete_stack_fail
STACK_STATUS=$(aws cloudformation describe-stacks --stack-name $NODE_ROLE_STACK_NAME --query 'Stacks[0].StackStatus' --output text || echo "STACK_NOT_FOUND")
echo $STACK_STATUS
DELETE_FAILED
5090a9d2b508:/apps# if [ "$STACK_STATUS" == "DELETE_FAILED" ]; then
    echo "Stack is in DELETE_FAILED state, using FORCE_DELETE_STACK"
    aws cloudformation delete-stack --stack-name $NODE_ROLE_STACK_NAME --deletion-mode FORCE_DELETE_STACK
else
    echo "Normal stack deletion"
    aws cloudformation delete-stack --stack-name $NODE_ROLE_STACK_NAME
fi
Stack is in DELETE_FAILED state, using FORCE_DELETE_STACK
```

2. Test-case 2: Stack deletion was never initiated
```
export NODE_ROLE_STACK_NAME=dummy_node_role
5090a9d2b508:/apps# STACK_STATUS=$(aws cloudformation describe-stacks --stack-name $NODE_ROLE_STACK_NAME --query 'Stacks[0].StackStatus' --output text || echo "STACK_NOT_FOUND")
echo $STACK_STATUS
CREATE_COMPLETE
5090a9d2b508:/apps# if [ "$STACK_STATUS" == "DELETE_FAILED" ]; then
    echo "Stack is in DELETE_FAILED state, using FORCE_DELETE_STACK"
    aws cloudformation delete-stack --stack-name $NODE_ROLE_STACK_NAME --deletion-mode FORCE_DELETE_STACK
else
    echo "Normal stack deletion"
    aws cloudformation delete-stack --stack-name $NODE_ROLE_STACK_NAME
fi
Normal stack deletion
```
