### PR TITLE
fetch VPC ID from stack output

### DIFF
--- a/tests/tekton-resources/tasks/setup/eks/awscli-vpc.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-vpc.yaml
@@ -22,10 +22,9 @@ spec:
       curl -s $(params.vpc-cfn-url) -o ./amazon-vpc-eks
       aws cloudformation --region $(params.region) deploy --stack-name $(params.stack-name)  --template-file ./amazon-vpc-eks
 
-      VPC_ID=$(aws ec2 describe-vpcs \
-          --filters "Name=tag:Name,Values=$(params.stack-name)-VPC" \
-          --query 'Vpcs[0].VpcId' \
-          --output text)
+      VPC_ID=$(aws cloudformation describe-stacks --stack-name $(params.stack-name) --query "Stacks[0].Outputs[?OutputKey=='VpcId'].OutputValue" --output text)
+
+      echo "VPC_ID: $(VPC_ID)"
 
       # Get all subnets with /12 CIDR blocks from the VPC
       SUBNETS=$(aws ec2 describe-subnets \


### PR DESCRIPTION
Issue #, if available:
VPCIDs, from previous stack deletion, may still exist leading to the vpc creation step pulling the orphaned VPCIDs which don't contain any subnets leading to step execution failing. This change fetches the VPCIDs from the recently created stack.

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
