### PR TITLE
Fix failure on pod identity scalability tests

### DIFF
--- a/tests/assets/eks-pod-identity/pod-default.yaml
+++ b/tests/assets/eks-pod-identity/pod-default.yaml
@@ -38,7 +38,7 @@ spec:
         start_epoch=$(date +%s%3N)
         # fetch credentials
         for i in $(seq 0 $((MAX_ATTEMPTS - 1))); do
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: $AUTH_TOKEN" http://169.254.170.23/v1/credentials)
+          status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 -H "Authorization: $AUTH_TOKEN" http://169.254.170.23/v1/credentials)
           if [ "$status_code" -eq 200 ]; then
             end_epoch=$(date +%s%3N)
             printf "Endpoint is reachable at try %d\n" "$i"

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
@@ -270,11 +270,9 @@ spec:
 
       # if p99.95 is equal to or more than 1 second, exit with failure
       int_p9995=$(echo "$p9995" | awk '{printf "%d", $1}')
+      echo "p99.95 is $p9995"
       if [ "$int_p9995" -lt 1 ]; then
-        echo "p99.95 is less than 1 second"
         echo "1" | tee $(results.datapoint.path)
       else
-        echo "p99.95 is 1 second or more"
         echo "0" | tee $(results.datapoint.path)
-        exit 1
       fi

--- a/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
+++ b/tests/tekton-resources/tasks/teardown/awscli-eks.yaml
@@ -47,12 +47,23 @@ spec:
       aws eks wait cluster-deleted --name $(params.cluster-name) --region $(params.region) $ENDPOINT_FLAG
       echo "Cluster is deleted..."
 
-      MANAGED_POLICY_ARN="arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
       for i in $(seq 1 $(params.namespace-count)); do
         PIA_ROLE_NAME=$(params.cluster-name)-pia-role-$i
         PIA_ROLE_EXISTS=$(aws iam get-role --role-name $PIA_ROLE_NAME --query 'Role.RoleName' --output text 2>/dev/null)
         if [ "$PIA_ROLE_EXISTS" == "$PIA_ROLE_NAME" ]; then
-          aws iam detach-role-policy --role-name $PIA_ROLE_NAME --policy-arn $MANAGED_POLICY_ARN
+          # Detach all attached managed policies
+          aws iam list-attached-role-policies --role-name "$PIA_ROLE_NAME" \
+            --query 'AttachedPolicies[*].PolicyArn' --output text | while read -r policy_arn; do
+            echo "Detaching managed policy: $policy_arn"
+            aws iam detach-role-policy --role-name "$PIA_ROLE_NAME" --policy-arn "$policy_arn"
+          done
+          # Delete all inline policies
+          aws iam list-role-policies --role-name "$PIA_ROLE_NAME" \
+            --query 'PolicyNames' --output text | while read -r policy_name; do
+            echo "Deleting inline policy: $policy_name"
+            aws iam delete-role-policy --role-name "$PIA_ROLE_NAME" --policy-name "$policy_name"
+          done
+          # Delete role
           aws iam delete-role --role-name $PIA_ROLE_NAME
           echo "Role $PIA_ROLE_NAME deleted successfully."
         else


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Fix failure on pod identity scalability tests:
1. add timeout on credential fetch
2. don't fail the metrics task on latency over 1s
3. fix on role policy detachment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
