### PR TITLE
Update to releases using the ghcr.io image repo

### DIFF
--- a/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
+++ b/infrastructure/k8s-config/clusters/kit-infrastructure/tekton-pipelines/tekton.yaml
@@ -17,10 +17,10 @@ spec:
     # exclude all
     /*
     # include releases
-    !/pipeline/previous/v0.47.1/release.yaml
-    !/triggers/previous/v0.23.1/release.yaml
-    !/triggers/previous/v0.23.1/interceptors.yaml
-    !/dashboard/previous/v0.35.0/release.yaml
+    !/pipeline/previous/v0.65.6/release.yaml
+    !/triggers/previous/v0.30.1/release.yaml
+    !/triggers/previous/v0.30.1/interceptors.yaml
+    !/dashboard/previous/v0.53.0/release.yaml
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
 kind: Kustomization
@@ -29,7 +29,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./pipeline/previous/v0.47.1
+  path: ./pipeline/previous/v0.65.6
   prune: true
   sourceRef:
     kind: Bucket
@@ -89,7 +89,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./triggers/previous/v0.23.1
+  path: ./triggers/previous/v0.30.1
   prune: true
   sourceRef:
     kind: Bucket
@@ -135,7 +135,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./triggers/previous/v0.23.1
+  path: ./triggers/previous/v0.30.1
   prune: true
   sourceRef:
     kind: Bucket
@@ -165,7 +165,7 @@ metadata:
   namespace: tekton-pipelines
 spec:
   interval: 2m0s
-  path: ./dashboard/previous/v0.35.0
+  path: ./dashboard/previous/v0.53.0
   prune: true
   sourceRef:
     kind: Bucket


### PR DESCRIPTION
Issue #, if available:
https://github.com/tektoncd/pipeline/issues/8870#issuecomment-3057956486

Description of changes:

Images have been moved to a new repo, instead of patching the release files going to try and update to the earliest release using the new repo location.

https://github.com/tektoncd/dashboard/releases/tag/v0.53.0
https://github.com/tektoncd/triggers/releases/tag/v0.30.1
https://github.com/tektoncd/pipeline/releases/tag/v0.65.6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
