### PR TITLE
Update kubernetes-version for controlplane

### DIFF
--- a/tests/tekton-resources/tasks/setup/kitctl/controlplane.yaml
+++ b/tests/tekton-resources/tasks/setup/kitctl/controlplane.yaml
@@ -42,7 +42,7 @@ spec:
     default: "m5.16xlarge"
     description: Instance type for the ETCD
   - name: kubernetes-version
-    default: "1.19"
+    default: "1.28"
     description: Kubernetes version for the guest cluster 
   steps:
   - name: setup-control-plane


### PR DESCRIPTION
Issue #, if available:

Description of changes:
updating k8s version 1.28 for compatibility with new pipelines controller. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
