### PR TITLE
Add resource limit to Pods and switch to use p99.9 metrics in Pod Identity scale tests

### DIFF
--- a/tests/assets/eks-pod-identity/pod-default.yaml
+++ b/tests/assets/eks-pod-identity/pod-default.yaml
@@ -9,6 +9,13 @@ spec:
   - name: app-with-awsapi
     image: public.ecr.aws/aws-cli/aws-cli:latest
     imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "120m"
+        memory: "2.5Mi"
+      limits:
+        cpu: "150m"
+        memory: "3Mi"
     env:
       - name: CLUSTER_NAME
         value: "{{.ClusterName}}"
@@ -25,61 +32,49 @@ spec:
       - -c
       - |
         AUTH_TOKEN=$(cat $AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE)
-        MAX_ATTEMPTS=7
-        INITIAL_DELAY=0.2  # 200ms
 
         DIMENSION_VALUE=$CLUSTER_NAME
         METRIC_MAX_RETRIES=5
         METRIC_RETRY_DELAY=1
 
-        # make 7 attempts on credential fetching with exponential retries, and calculate the time taken
+        # make an attempt on credential fetching, and calculate the time taken
         # push metrics on time taken on credential fetching
         # to minimize failure from cloudwatch metrics, add retries on put-metric-data
         start_epoch=$(date +%s%3N)
         # fetch credentials
-        for i in $(seq 0 $((MAX_ATTEMPTS - 1))); do
-          status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 -H "Authorization: $AUTH_TOKEN" http://169.254.170.23/v1/credentials)
-          if [ "$status_code" -eq 200 ]; then
-            end_epoch=$(date +%s%3N)
-            printf "Endpoint is reachable at try %d\n" "$i"
+        status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 -H "Authorization: $AUTH_TOKEN" http://169.254.170.23/v1/credentials)
+        if [ "$status_code" -eq 200 ]; then
+          end_epoch=$(date +%s%3N)
+          printf "Endpoint is reachable at try %d\n" "$i"
 
-            latency_ms=$((end_epoch - start_epoch))
-            latency_sec=$(awk "BEGIN { print $latency_ms / 1000 }")
+          latency_ms=$((end_epoch - start_epoch))
+          latency_sec=$(awk "BEGIN { print $latency_ms / 1000 }")
 
-            # send CredentialFetchLatency metric
-            for ((j=1; j<=METRIC_MAX_RETRIES; j++)); do
-              aws cloudwatch put-metric-data \
-                --namespace "$NAMESPACE" \
-                --metric-name "$METRIC_LATENCY_NAME" \
-                --dimensions "$DIMENSION_NAME=$DIMENSION_VALUE" \
-                --value "$latency_sec" \
-                --unit Seconds && {
-                  echo "Metric CredentialFetchLatency sent successfully."
-                  break
-              }
+          # send CredentialFetchLatency metric
+          for ((j=1; j<=METRIC_MAX_RETRIES; j++)); do
+            aws cloudwatch put-metric-data \
+              --namespace "$NAMESPACE" \
+              --metric-name "$METRIC_LATENCY_NAME" \
+              --dimensions "$DIMENSION_NAME=$DIMENSION_VALUE" \
+              --value "$latency_sec" \
+              --unit Seconds && {
+                echo "Metric CredentialFetchLatency sent successfully."
+                break
+            }
 
-              if [ "$j" -lt "$METRIC_MAX_RETRIES" ]; then
-                echo "Attempt $j failed. Retrying in $METRIC_RETRY_DELAY seconds..." >&2
-                sleep $METRIC_RETRY_DELAY
-                METRIC_RETRY_DELAY=$((METRIC_RETRY_DELAY * 2)) # exponential backoff
-              else
-                echo "Failed to send metric CredentialFetchLatency after $METRIC_MAX_RETRIES attempts." >&2
-                exit 1
-              fi
-            done
-
-            break
-          fi
-
-          if [ "$i" -eq $((MAX_ATTEMPTS - 1)) ]; then
-            echo "Max attempts reached. Exiting with failure."
-            exit 1
-          fi
-
-          SLEEP_TIME=$(echo "$INITIAL_DELAY * (2 ^ $i)" | bc -l)
-          printf "Failed. Sleeping %.3f seconds before retry...\n" "$SLEEP_TIME"
-          sleep "$SLEEP_TIME"
-        done
+            if [ "$j" -lt "$METRIC_MAX_RETRIES" ]; then
+              echo "Attempt $j failed. Retrying in $METRIC_RETRY_DELAY seconds..." >&2
+              sleep $METRIC_RETRY_DELAY
+              METRIC_RETRY_DELAY=$((METRIC_RETRY_DELAY * 2)) # exponential backoff
+            else
+              echo "Failed to send metric CredentialFetchLatency after $METRIC_MAX_RETRIES attempts." >&2
+              exit 1
+            fi
+          done
+        else
+          echo "Failed to fetch credential"
+          exit 1
+        fi
 
         # it is noted that a Pod with host network will fallback to Node role permissions that includes this s3 access
         # however, in our test case, we are not using host network

--- a/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -79,11 +79,11 @@ spec:
   - name: cl2-eks-pod-identity-pods
     default: "5000"
   - name: cl2-default-qps
-    default: "100"
+    default: "200"
   - name: cl2-default-burst
     default: "200"
   - name: cl2-uniform-qps
-    default: "100"
+    default: "200"
   - name: cl2-metric-dimension-name
     description: "default metric dimension name"
     default: "ClusterName"
@@ -97,9 +97,9 @@ spec:
     description: "default metric period"
     default: "300"
   - name: timeout-pia-pod-creation
-    default: "80s"
+    default: "40s"
   - name: timeout-pia-pod-startup
-    default: "60s"
+    default: "20s"
   - name: launch-template-ami
     default: ""
     description: "Launch template ImageId value, which may be an AMI ID or resolve:ssm reference. By default resolve to the lates AL2023 ami for cluster version"

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
@@ -18,13 +18,13 @@ spec:
     default: "5000"
   - name: cl2-default-qps
     description: "default qps"
-    default: "100"
+    default: "200"
   - name: cl2-default-burst
     description: "default burst"
     default: "200"
   - name: cl2-uniform-qps
     description: "uniform qps"
-    default: "100"
+    default: "200"
   - name: cl2-metric-dimension-name
     description: "default metric dimension name"
     default: "ClusterName"
@@ -228,14 +228,14 @@ spec:
         --start-time "$START_TIME" \
         --end-time "$END_TIME" \
         --period "$PERIOD" \
-        --extended-statistics p50 p99 p99.95 \
+        --extended-statistics p50 p99 p99.9 \
         --output json)
 
       # extract p50 p99 p99.95 of credential fetching
       latest=$(echo "$response" | jq -r '.Datapoints | sort_by(.Timestamp) | last')
       p50=$(echo "$latest" | jq -r '."ExtendedStatistics"."p50" // "N/A"')
       p99=$(echo "$latest" | jq -r '."ExtendedStatistics"."p99" // "N/A"')
-      p9995=$(echo "$latest" | jq -r '."ExtendedStatistics"."p99.95" // "N/A"')
+      p999=$(echo "$latest" | jq -r '."ExtendedStatistics"."p99.9" // "N/A"')
 
       response=$(aws cloudwatch get-metric-statistics \
         --region "$REGION" \
@@ -260,7 +260,7 @@ spec:
         "rate": $rate,
         "p50": $p50,
         "p99": $p99,
-        "p99.95": $p9995
+        "p99.9": $p999
       }
       EOF
 
@@ -268,10 +268,10 @@ spec:
       ls -larth
       aws s3 cp . s3://$S3_RESULT_PATH/  --recursive
 
-      # if p99.95 is equal to or more than 1 second, exit with failure
-      int_p9995=$(echo "$p9995" | awk '{printf "%d", $1}')
-      echo "p99.95 is $p9995"
-      if [ "$int_p9995" -lt 1 ]; then
+      # if p99.9 is equal to or more than 1 second, exit with failure
+      int_p999=$(echo "$p999" | awk '{printf "%d", $1}')
+      echo "p99.9 is $p999"
+      if [ "$int_p999" -lt 1 ]; then
         echo "1" | tee $(results.datapoint.path)
       else
         echo "0" | tee $(results.datapoint.path)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add resource limit to Pods and switch to use p99.9 metrics in Pod Identity scale tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
