### PR TITLE
Fix launch template name for MNG creation

### DIFF
--- a/tests/tekton-resources/tasks/setup/eks/awscli-mng.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-mng.yaml
@@ -72,7 +72,11 @@ spec:
       create_and_validate_dp_nodes()
       {
         node_group_name=$node_group-$1
-        launch_template_name=$(params.cluster-name)-launchTemplate
+        # by default assume <cluster-name>-launchTemplate convention
+        launch_template_name="$(params.cluster-name)-launchTemplate"
+        if [ -n "$(params.launch-template-name)" ]; then
+          launch_template_name="$(params.launch-template-name)"
+        fi
         CREATED_NODEGROUP=$(aws eks $ENDPOINT_FLAG --region $(params.region) list-nodegroups --cluster-name $(params.cluster-name)  --query 'nodegroups[?@==`'$node_group_name'`]' --output text)
         EC2_INSTANCES=$3
         if [ "$CREATED_NODEGROUP" == "" ]; then


### PR DESCRIPTION
Issue #, if available:

There is mismatch between launch template name while creation and usage. Fixing the launch template used while creating MNG

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
