### PR TITLE
Pass aws-ebs-csi-driver-version as param to fix failing scale test for v1.32

### DIFF
--- a/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -109,6 +109,9 @@ spec:
     default: ""
     description: "Launch template ImageId value, which may be an AMI ID or resolve:ssm reference. By default resolve to the lates AL2023 ami for cluster version"
     type: string
+  - name: aws-ebs-csi-driver-version
+    default: release-1.53
+    description: The release version for aws ebs csi driver.
   tasks:
   - name: slack-notification
     params:
@@ -166,6 +169,8 @@ spec:
       value: $(params.cluster-name)
     - name: kubernetes-version
       value: $(params.kubernetes-version)
+    - name: aws-ebs-csi-driver-version
+      value: $(params.aws-ebs-csi-driver-version)
     retries: 3
     runAfter:
     - create-cluster-node-role


### PR DESCRIPTION


Description / Motivation: v1.32 does not work correctly with ebs csi driver version > 1.45. In order to pass custom ebs csi driver version for v1.32, the param `aws-ebs-csi-driver-version` needs to be added to the pipeline and task. This commit allows passing of the `aws-ebs-csi-driver-version param` to the pipeline and to the `awscli-eks-cluster-create-with-vpc-stack` task.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
