### PR TITLE
fix: create per iteration folder for output iteration results in a single build

### DIFF
--- a/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
@@ -106,7 +106,7 @@ spec:
       for ((i=1; i<=ITERATIONS; i++)); do
         echo "--- Starting iteration $i of $ITERATIONS ---"
 
-        ENABLE_EXEC_SERVICE=false ./clusterloader --kubeconfig=$KUBECONFIG --testconfig=$(workspaces.source.path)/kubernetes-iteration-toolkit/tests/assets/sustained-throughput/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path) --alsologtostderr --v=2
+        ENABLE_EXEC_SERVICE=false ./clusterloader --kubeconfig=$KUBECONFIG --testconfig=$(workspaces.source.path)/kubernetes-iteration-toolkit/tests/assets/sustained-throughput/config.yaml --testoverrides=$(workspaces.source.path)/overrides.yaml --nodes=$(params.nodes) --provider=eks --report-dir=$(workspaces.results.path)/${i} --alsologtostderr --v=2
 
         if [ $? -ne 0 ]; then
           echo "Iteration $i failed."


### PR DESCRIPTION
In this PR, we create a separate folder for each iteration in a single PCP load-test. This would allow us to plot different iterations on PerfDash as different builds of the same run. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
