### PR TITLE
fix: use only integers for build-names in pcp-throughput-tests

### DIFF
--- a/tests/assets/sustained-throughput/config.yaml
+++ b/tests/assets/sustained-throughput/config.yaml
@@ -5,7 +5,7 @@
 
 {{$SCHEDULER_THROUGHPUT_THRESHOLD := DefaultParam .CL2_SCHEDULER_THROUGHPUT_THRESHOLD 400}}
 
-name: direct-scheduler-throughput
+name: load
 namespace:
   number: 1
 tuningSets:

--- a/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
@@ -156,6 +156,6 @@ spec:
       # Upload each iteration folder as <timestamp>-<i>/artifacts/
       for ((i=1; i<=$(params.iterations); i++)); do
         if [ -d "$i" ]; then
-          aws s3 cp "$i" "s3://${S3_BASE}/${TIMESTAMP}-${i}/" --recursive
+          aws s3 cp "$i" "s3://${S3_BASE}/${TIMESTAMP}${i}/" --recursive
         fi
       done


### PR DESCRIPTION
Issue #, if available:
Perfdash expects all buildnames to be a valid integer, so having suffix `-1` `-2` will break parsing, fixing by simply appending iteration number.

Changing name as well as testname accepts only one of the following values:
```
  - load
  - density
  - density_pod-affinity
  - density_pod-anti-affinity
  - density_pod-topology-spread
  - density_vanilla
```
Ref: https://github.com/kubernetes/perf-tests/blob/master/perfdash/config.go#L310-L340


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
