### PR TITLE
feat: add max-pods support with mng launch-template

### DIFF
--- a/tests/assets/eks_node_group_launch_template_pcp.json
+++ b/tests/assets/eks_node_group_launch_template_pcp.json
@@ -1,0 +1,73 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Create an EKS Node Group Launch Template",
+    "Parameters": {
+        "LaunchTemplateName": {
+            "Type": "String",
+            "Description": "Name of the Launch Template"
+        },
+        "ClusterName": {
+            "Type": "String",
+            "Description": "Name of the Cluster"
+        },
+        "SSHKeyName": {
+            "Type": "String",
+            "Description": "SSH Key Name for EC2 instances"
+        }
+    },
+    "Resources": {
+        "NodeGroupLaunchTemplate": {
+            "Type": "AWS::EC2::LaunchTemplate",
+            "Properties": {
+                "LaunchTemplateName": { "Ref": "LaunchTemplateName" },
+                "LaunchTemplateData": {
+                    "KeyName": { "Ref": "SSHKeyName" },
+                    "BlockDeviceMappings": [
+                        {
+                            "DeviceName": "/dev/xvda",
+                            "Ebs": {
+                                "VolumeSize": 20,
+                                "VolumeType": "gp2"
+                            }
+                        }
+                    ],
+                    "MetadataOptions": {
+                        "HttpPutResponseHopLimit": 2,
+                        "HttpEndpoint": "enabled",
+                        "HttpTokens": "required"
+                    },
+                    "UserData": {
+                        "Fn::Base64": {
+                            "Fn::Join": ["\n", [
+                                "Content-Type: multipart/mixed; boundary=\"BOUNDARY\"",
+                                "MIME-Version: 1.0",
+                                "",
+                                "--BOUNDARY",
+                                "Content-Type: application/node.eks.aws",
+                                "MIME-Version: 1.0",
+                                "",
+                                "---",
+                                "apiVersion: node.eks.aws/v1alpha1",
+                                "kind: NodeConfig",
+                                "spec:",
+                                "  cluster:",
+                                {"Fn::Sub": "    name: ${ClusterName}"},
+                                "  kubelet:",
+                                "    config:",
+                                "      maxPods: 250",
+                                "",
+                                "--BOUNDARY--"
+                            ]]
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "NodeGroupLaunchTemplateName": {
+            "Description": "Name of the Node Group Launch Template",
+            "Value": { "Ref": "NodeGroupLaunchTemplate" }
+        }
+    }
+}

--- a/tests/tekton-resources/pipelines/eks/awscli-eks-cl2-pcp-scheduler-throughput.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-eks-cl2-pcp-scheduler-throughput.yaml
@@ -28,7 +28,7 @@ spec:
   - name: slack-message
   - name: vpc-cfn-url
   - name: ng-cfn-url
-    default: "https://raw.githubusercontent.com/awslabs/kubernetes-iteration-toolkit/main/tests/assets/eks_node_group_launch_template.json"
+    default: "https://raw.githubusercontent.com/awslabs/eks-perf-tests/refs/heads/main/tests/assets/eks_node_group_launch_template_pcp.json"
     type: string
   - name: kubernetes-version
     default: "1.33"


### PR DESCRIPTION
Description of changes:

Create a separate MNG launch-template for PCP clusters. This is to allow a higher `--max-pods=250` limits for kubelet. The default for smaller instances in EKS is 110. This is wasteful for throughput tests as we are unable to schedule a large number of pods for throughput tests to successfully complete. 
Ref: https://docs.aws.amazon.com/eks/latest/userguide/choosing-instance-type.html


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
