### PR TITLE
feat: add run-id dimension to metrics for dashboard URL

### DIFF
--- a/tests/tekton-resources/pipelines/eks/awscli-eks-cl2-pcp-scheduler-throughput.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-eks-cl2-pcp-scheduler-throughput.yaml
@@ -227,6 +227,8 @@ spec:
       value: $(params.kubernetes-version)
     - name: metric-name
       value: $(params.metric-name)
+    - name: run-id
+      value: $(context.pipelineRun.name)
     runAfter:
       - generate
     taskRef:

--- a/tests/tekton-resources/tasks/addons/cw-metric.yaml
+++ b/tests/tekton-resources/tasks/addons/cw-metric.yaml
@@ -21,9 +21,15 @@ spec:
       description: "The unit of the metrics"
     - name: value
       description: "The value for the metric"
+    - name: run-id
+      description: "Pipeline runId required for populating runId dimension to be queried for dashboards later"
+      default: ""
   steps:
   - name: cw-emit
     image: amazon/aws-cli
     script: |
       aws sts get-caller-identity
       aws cloudwatch --region $(params.region) put-metric-data --metric-name $(params.metric-name) --namespace $(params.namespace) --dimensions Nodes=$(params.dimensions) --unit $(params.unit) --value $(params.value) 
+      if [ -n "$(params.run-id)" ]; then
+        aws cloudwatch --region $(params.region) put-metric-data --metric-name $(params.metric-name) --namespace $(params.namespace) --dimensions Nodes=$(params.dimensions),RunId=$(params.run-id) --value $(params.value)
+      fi


### PR DESCRIPTION
Description of changes:

Adding a new `run-id` dimension to extract a unique identifier for each pipelinerun to be able to redirect from dashboards directly to pipelinRuns

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
