### PR TITLE
fix: add support for run-id dimension in metric publish

### DIFF
--- a/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
+++ b/tests/tekton-resources/pipelines/eks/awscli-cl2-load-with-addons-slos.yaml
@@ -396,6 +396,8 @@ spec:
       value: $(tasks.generate.results.datapoint)
     - name: namespace
       value: $(params.kubernetes-version)
+    - name: run-id
+      value: $(context.pipelineRun.name)
     runAfter:
     - generate
     taskRef:


### PR DESCRIPTION
Description of changes:
Add `run-id` dimension publishing for standard load tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
