### PR TITLE
Update golang image from 1.25 to 1.26 in all clusterloader tasks

### DIFF
--- a/tests/tekton-resources/tasks/generators/clusterloader/load-aiml-large-pre-training.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-aiml-large-pre-training.yaml
@@ -100,7 +100,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-aiml-test
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-aiml-multiple-fine-tuning.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-aiml-multiple-fine-tuning.yaml
@@ -100,7 +100,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-aiml-test
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-networking.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-networking.yaml
@@ -65,7 +65,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-pod-identity.yaml
@@ -99,7 +99,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load-slos.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load-slos.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/load.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/load.yaml
@@ -61,7 +61,7 @@ spec:
       git checkout $(params.cl2-branch)
       git branch
   - name: prepare-loadtest
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)

--- a/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
+++ b/tests/tekton-resources/tasks/generators/clusterloader/sustained-scheduler-throughput.yaml
@@ -70,7 +70,7 @@ spec:
       git fetch origin --verbose --tags
       git branch
   - name: prepare-loadtest
-    image: golang:1.25
+    image: golang:1.26
     workingDir: $(workspaces.source.path)
     script: |
       S3_RESULT_PATH=$(params.results-bucket)


### PR DESCRIPTION
The upstream kubernetes/perf-tests repo updated its go.mod to require Go >= 1.26.4. The clusterloader task definitions still use a Go 1.25 image, causing builds to fail with:

```
go: go.mod requires go >= 1.26.4 (running go 1.25.11; GOTOOLCHAIN=local)
```

This PR bumps the golang image from 1.25 to 1.26 across all clusterloader tasks.