### PR TITLE
Add pruner config to TektonConfig and increase retention count of PipelineRuns

### DIFF
--- a/infrastructure/addons/tekton/config.yaml
+++ b/infrastructure/addons/tekton/config.yaml
@@ -70,6 +70,12 @@ spec:
                   args:
                   - --external-logs=http://tekton-log-server.tekton-pipelines.svc.cluster.local:3000
                   - --stream-logs=false
+  pruner:
+    disabled: false
+    keep: 1000
+    resources:
+    - pipelinerun
+    schedule: "0 8 * * *"
   hub:
     options: {}
   result:


### PR DESCRIPTION
Codifies the pruner settings that were previously only applied as an operator default (keep: 100). Increases retention to 1000 PipelineRuns (~6-8 weeks at current run rates) for better historical visibility.
