### PR TITLE
fix(addons): set TLS 1.2+ ssl-policy on perfdash/flux/tekton ALB ingr…

### DIFF
--- a/infrastructure/addons/flux/ingress.yaml
+++ b/infrastructure/addons/flux/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: "${CERT_ARN}"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09
     alb.ingress.kubernetes.io/auth-type: oidc
     alb.ingress.kubernetes.io/auth-idp-oidc: '{"issuer":"${FEDERATE_OIDC_ISSUER}","authorizationEndpoint":"${FEDERATE_OIDC_AUTH_ENDPOINT}","tokenEndpoint":"${FEDERATE_OIDC_TOKEN_ENDPOINT}","userInfoEndpoint":"${FEDERATE_OIDC_USERINFO_ENDPOINT}","secretName":"federate-oidc-secret"}'
     alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate

--- a/infrastructure/addons/perfdash/ingress.yaml
+++ b/infrastructure/addons/perfdash/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: "${CERT_ARN}"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09
     alb.ingress.kubernetes.io/auth-type: oidc
     alb.ingress.kubernetes.io/auth-idp-oidc: '{"issuer":"${FEDERATE_OIDC_ISSUER}","authorizationEndpoint":"${FEDERATE_OIDC_AUTH_ENDPOINT}","tokenEndpoint":"${FEDERATE_OIDC_TOKEN_ENDPOINT}","userInfoEndpoint":"${FEDERATE_OIDC_USERINFO_ENDPOINT}","secretName":"federate-oidc-secret"}'
     alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate

--- a/infrastructure/addons/tekton/dashboards/ingress.yaml
+++ b/infrastructure/addons/tekton/dashboards/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: "${CERT_ARN}"
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09
     alb.ingress.kubernetes.io/auth-type: oidc
     alb.ingress.kubernetes.io/auth-idp-oidc: '{"issuer":"${FEDERATE_OIDC_ISSUER}","authorizationEndpoint":"${FEDERATE_OIDC_AUTH_ENDPOINT}","tokenEndpoint":"${FEDERATE_OIDC_TOKEN_ENDPOINT}","userInfoEndpoint":"${FEDERATE_OIDC_USERINFO_ENDPOINT}","secretName":"federate-oidc-secret"}'
     alb.ingress.kubernetes.io/auth-on-unauthenticated-request: authenticate


### PR DESCRIPTION
Fix(addons): enforce TLS 1.2+ on public dashboard ALBs

Set alb.ingress.kubernetes.io/ssl-policy to ```ELBSecurityPolicy-TLS13-1-2-Res-PQ-2025-09``` on the three internet-facing ingresses (perfdash, flux, tekton). Without it the ALB listeners default to a legacy policy that negotiates TLS 1.0/1.1, tripping the AWS AppSec finding "Public Endpoint Should Only Support TLS Versions 1.2 or Higher".

Policy is the GENERAL-track ALB recommendation from the Secure Transport TLS Configuration Guidance (commercial region, non-FIPS).