### PR TITLE
Wait 120s after cluster is ACTIVE before connecting (awscli-cp-with-pcp)

### DIFF
--- a/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-pcp.yaml
+++ b/tests/tekton-resources/tasks/setup/eks/awscli-cp-with-pcp.yaml
@@ -61,6 +61,11 @@ spec:
         aws eks create-cluster --name $(params.cluster-name) --region $(params.region) --kubernetes-version $(params.kubernetes-version) --role-arn $SERVICE_ROLE_ARN --resources-vpc-config subnetIds=$subnets,securityGroupIds=$sg --control-plane-scaling-config tier=$(params.control-plane-tier) $ENDPOINT_FLAG
       fi
       aws eks $ENDPOINT_FLAG --region $(params.region) wait cluster-active --name $(params.cluster-name)
+      # Cluster is ACTIVE (create succeeded). Wait for the API server endpoint to
+      # become resolvable/discoverable before connecting with kubectl: the endpoint
+      # instances take time to come up and the Route53 record has a ~60s TTL, so
+      # connecting immediately can fail with "no such host".
+      sleep 120
   - name: write-kubeconfig
     image: alpine/k8s:1.35.0
     script: |


### PR DESCRIPTION
## What

Add `sleep 120` **after** `aws eks wait cluster-active` in the `awscli-eks-cluster-create-with-pcp-stack` task, so subsequent steps don't connect to the cluster API server endpoint immediately after creation.

## Why

Loadtests intermittently failed during connect with:

```
couldn't get current server API group list: Get "https://<id>.sk1.beta.us-west-2.clusters.wesley.amazonaws.com/api?timeout=32s": dial tcp: lookup <id>...: no such host
```

This is a transient issue right after creation: the API server endpoint instances take time to come up and be discoverable, and the Route53 record has a ~60s TTL. The fix is to wait until the cluster create is signaled successful (`wait cluster-active`) and then give the endpoint time to become resolvable before kubectl connects.
